### PR TITLE
fix: CD uses PRs for manifest updates

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -143,7 +143,7 @@ sequenceDiagram
     CI-->>GH: ✓ Passed
     GH->>CD: Trigger CD
     CD->>GHCR: Build & push image (sha-XXXXXXXX)
-    CD->>GH: Update kustomization.yaml [skip ci]
+    CD->>GH: Create PR updating kustomization.yaml
     GH->>Argo: Git change detected
     Argo->>K8s: Sync environment
     K8s-->>Dev: ✓ Deployed

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -78,7 +78,8 @@ jobs:
     if: github.event.workflow_run.head_branch == 'dev'
     
     permissions:
-      contents: write  # Required to push commits
+      contents: write
+      pull-requests: write
     
     steps:
       - name: Checkout code
@@ -98,20 +99,20 @@ jobs:
           
           echo "Updated dev overlay to use image tag: $IMAGE_TAG"
       
-      - name: Commit and push changes
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          git config --global user.name "github-actions[bot]"
-          git config --global user.email "github-actions[bot]@users.noreply.github.com"
-          
-          git add infra/argocd/overlays/dev/kustomization.yaml
-          if git diff --cached --quiet; then
-            echo "No changes to commit"
-          else
-            git commit -m "chore: update dev image to sha-${{ needs.build-and-push.outputs.short_sha }} [skip ci]"
-            git push https://${{ github.actor }}:${GH_TOKEN}@github.com/${{ github.repository }}.git dev
-          fi
+      - name: Create pull request
+        uses: peter-evans/create-pull-request@v6
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          commit-message: "chore: update dev image to sha-${{ needs.build-and-push.outputs.short_sha }} [skip ci]"
+          title: "chore: update dev image to sha-${{ needs.build-and-push.outputs.short_sha }}"
+          body: |
+            Automated update of dev kustomization image tag.
+            
+            - Image: sha-${{ needs.build-and-push.outputs.short_sha }}
+          branch: "cd/update-dev-${{ needs.build-and-push.outputs.short_sha }}"
+          base: dev
+          add-paths: |
+            infra/argocd/overlays/dev/kustomization.yaml
 
   update-stage-prod-manifest:
     name: Update Stage and Prod Manifests
@@ -120,7 +121,8 @@ jobs:
     if: github.event.workflow_run.head_branch == 'main'
 
     permissions:
-      contents: write  # Required to push commits
+      contents: write
+      pull-requests: write
 
     steps:
       - name: Checkout code
@@ -141,20 +143,21 @@ jobs:
 
           echo "Updated stage and prod overlays to use image tag: $IMAGE_TAG"
 
-      - name: Commit and push changes
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          git config --global user.name "github-actions[bot]"
-          git config --global user.email "github-actions[bot]@users.noreply.github.com"
-
-          git add infra/argocd/overlays/stage/kustomization.yaml infra/argocd/overlays/prod/kustomization.yaml
-          if git diff --cached --quiet; then
-            echo "No changes to commit"
-          else
-            git commit -m "chore: update stage/prod image to sha-${{ needs.build-and-push.outputs.short_sha }} [skip ci]"
-            git push https://${{ github.actor }}:${GH_TOKEN}@github.com/${{ github.repository }}.git main
-          fi
+      - name: Create pull request
+        uses: peter-evans/create-pull-request@v6
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          commit-message: "chore: update stage/prod image to sha-${{ needs.build-and-push.outputs.short_sha }} [skip ci]"
+          title: "chore: update stage/prod image to sha-${{ needs.build-and-push.outputs.short_sha }}"
+          body: |
+            Automated update of stage/prod kustomization image tags.
+            
+            - Image: sha-${{ needs.build-and-push.outputs.short_sha }}
+          branch: "cd/update-stage-prod-${{ needs.build-and-push.outputs.short_sha }}"
+          base: main
+          add-paths: |
+            infra/argocd/overlays/stage/kustomization.yaml
+            infra/argocd/overlays/prod/kustomization.yaml
 
   security-scan:
     name: Security Scan

--- a/docs/CI_CD.md
+++ b/docs/CI_CD.md
@@ -127,7 +127,7 @@ images:
     newTag: sha-a1b2c3d4  # ← Updated by CD
 ```
 
-**Commit Message**: `chore: update dev image to sha-XXXXXXXX [skip ci]`
+**PR Title**: `chore: update dev image to sha-XXXXXXXX`
 
 **Result**: ArgoCD detects change and syncs `dex-dev` namespace
 
@@ -145,7 +145,7 @@ images:
     newTag: sha-a1b2c3d4  # ← Updated by CD
 ```
 
-**Commit Message**: `chore: update stage/prod image to sha-XXXXXXXX [skip ci]`
+**PR Title**: `chore: update stage/prod image to sha-XXXXXXXX`
 
 **Result**: ArgoCD syncs `dex-stage` and `dex-prod` namespaces
 
@@ -225,7 +225,7 @@ sequenceDiagram
     CI-->>GH: ✓ CI passes
     GH->>CD: Trigger CD workflow
     CD->>GHCR: Build & push image (sha-XXXXXXXX)
-    CD->>GH: Update infra/argocd/overlays/dev/kustomization.yaml
+    CD->>GH: Create PR updating dev kustomization.yaml
     GH->>Argo: Git change detected
     Argo->>K8s: Sync dex-dev namespace
     K8s-->>Argo: ✓ Sync complete
@@ -249,7 +249,7 @@ sequenceDiagram
     CI-->>GH: ✓ CI passes
     GH->>CD: Trigger CD workflow
     CD->>GHCR: Build & push image (sha-XXXXXXXX)
-    CD->>GH: Update stage/prod kustomization.yaml
+    CD->>GH: Create PR updating stage/prod kustomization.yaml
     GH->>Argo: Git change detected
     Argo->>K8s: Sync dex-stage & dex-prod
     K8s-->>Argo: ✓ Sync complete
@@ -508,16 +508,6 @@ docker pull ghcr.io/data-literate/dex:sha-XXXXXXXX
 
 # Check pod image
 kubectl get pod -n dex-dev -o jsonpath='{.items[0].spec.containers[0].image}'
-```
-
-### [skip ci] Not Working
-
-```bash
-# Verify commit message format
-git log --format="%s" -1
-
-# Should contain: [skip ci] or [ci skip]
-# CD commits use: [skip ci] to avoid recursive builds
 ```
 
 ## Security Considerations


### PR DESCRIPTION
## Summary\n- Switch CD workflow to open PRs for kustomization updates (protected branches)\n- Add PR permissions to CD workflow\n- Update CI/CD docs and workflow README\n\n## Why\nProtected branches reject direct pushes. PR-based updates fix failing CD runs.\n\n## Testing\n- Not required (workflow/docs change only)