### PR TITLE
feat(secops): PrivacyGuard — PII interception for outbound LLM calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ The 1.x versions were published before the project had:
 
 - A confirmed product positioning (now: local-first Data + ML + AI workbench for individuals and small teams)
 - A stable public API surface
-- User feedback validating the design
+- User feedback validating the design.
 
 ### When we'll reach 1.0
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,19 +1,19 @@
 # CLAUDE.md — DEX (dataenginex)
 
 Brief answers only. No explanations unless asked.
-Goal is to save Claude code tokens for lower cost without loosing quality.
+Goal is to save Claude code tokens for lower cost without losing quality.
 
 > Repo-specific context. Workspace-level rules, coding standards, and git conventions are in `../CLAUDE.md`.
 
 ## Project Overview
 
-**DEX** — unified Data + ML + AI framework. Config-driven, self-hosted, production-ready.
+**DEX** — unified Data + ML + AI library. Config-driven, self-hosted, local-first. Pure Python — no bundled HTTP server.
 
 | Package | Location | Purpose |
 |---------|----------|---------|
-| `dataenginex` | `src/dataenginex/` | Core framework — config, registry, CLI, API, ML, AI (routing, runtime, memory, observability, workflows) |
+| `dataenginex` | `src/dataenginex/` | Core library — config, registry, CLI, pipelines, ML, AI, PrivacyGuard |
 
-**Stack:** Python 3.13+ · FastAPI · DuckDB · structlog · Pydantic · Click · Rich · uv · Ruff · mypy strict · pytest
+**Stack:** Python 3.13+ · DuckDB · structlog · Pydantic · Click · pyarrow · croniter · httpx · prometheus-client · uv · Ruff · mypy strict · pytest
 
 **Version:** `uv run poe version`
 
@@ -40,8 +40,8 @@ uv run poe test-cov       # Tests with coverage
 dex validate dex.yaml     # Validate config file
 dex version               # Show version + environment
 
-# Run
-uv run poe dev            # Dev server (uvicorn reload, port 17000)
+# Dev
+uv run poe dev            # Dev server (uvicorn reload, port 17000) — for examples/API testing only
 uv run poe docker-up      # Docker compose up
 uv run poe docker-down    # Docker compose down
 
@@ -49,6 +49,16 @@ uv run poe docker-down    # Docker compose down
 uv run poe uv-sync        # Sync deps from lockfile
 uv run poe uv-lock        # Regenerate lockfile
 uv run poe security       # Audit deps for vulnerabilities
+```
+
+## Optional Extras
+
+```bash
+pip install "dataenginex[cloud]"        # S3, GCS, BigQuery connectors
+pip install "dataenginex[postgres]"     # asyncpg for Postgres lineage
+pip install "dataenginex[qdrant]"       # Qdrant vector store
+pip install "dataenginex[queue]"        # arq background jobs
+pip install 'litellm>=1.83.3' --no-deps # LLM routing (separate: pins python-dotenv)
 ```
 
 ______________________________________________________________________

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Optional integrations install only what you need:
 | `[cloud]` | `boto3`, `google-cloud-storage`, `google-cloud-bigquery` | S3 / GCS / BigQuery sources & sinks |
 | `[ml]` | `scikit-learn`, `xgboost`, `sentence-transformers` | Train classical ML models, generate embeddings |
 | `[tracking]` | `mlflow` | Experiment tracking via MLflow |
-| `[data]` | `pyspark`, `databricks-cli` | Distributed data processing |
+| `[data]` | `pyspark`, `databricks-cli` | PySpark connector + dbt CLI connector (run dbt models as pipeline steps) |
 
 > **LiteLLM** must be installed separately due to a `python-dotenv` pin conflict:
 >
@@ -63,7 +63,8 @@ ______________________________________________________________________
 | Retrieval | BM25 + dense + hybrid | — |
 | Persistence | DuckDB (`.dex/store.duckdb`) | — |
 | Logging | structlog | — |
-| Privacy | PII detection + masking + audit | — |
+| Privacy | PrivacyGuard — PII detection, masking strategies, outbound call audit | — |
+| Connectors | CSV, Parquet, DuckDB, REST, Kafka | PySpark (`[data]`), dbt CLI (`[data]`) |
 
 **Local-first by default.** A fresh `pip install dataenginex` requires no external services — DuckDB is embedded; nothing reaches the network unless you explicitly configure it (or call a hosted LLM).
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -124,20 +124,22 @@ DataEngineXError
 | `core/` | ABCs, registry, exceptions |
 | `cli/` | `dex` CLI (validate, version, init) |
 | `api/` | HTTP helpers: error types, response models |
-| `data/` | Connectors, pipeline runner, quality, profiler |
+| `data/connectors/` | Built-in connectors: CSV, Parquet, DuckDB, REST, Kafka, **Spark**, **dbt** |
+| `data/pipeline/` | Pipeline runner, transforms, quality, profiler |
 | `ml/` | Classical ML: training, registry, serving, drift |
 | `ai/` | LLM, agents, RAG, vectorstore, memory, observability |
 | `orchestration/` | DriftScheduler, background tasks |
 | `middleware/` | structlog config, Prometheus metrics |
 | `lakehouse/` | Storage backends, catalog, partitioning |
 | `warehouse/` | SQL transforms, lineage |
+| `secops/` | **PrivacyGuard** — PII detection, masking strategies, outbound-call audit |
 | `plugins/` | Entry-point discovery |
 
 ## Tech Stack
 
 | Component | Built-in | Extra |
 |-----------|----------|-------|
-| Data Engine | DuckDB | PySpark (`[spark]`) |
+| Data Engine | DuckDB | PySpark / dbt CLI (`[data]`) |
 | Orchestration | croniter scheduler | — |
 | ML Tracking | JSON-based | MLflow (`[tracking]`) |
 | Model Serving | Built-in predictor | — |
@@ -148,6 +150,7 @@ DataEngineXError
 | Logging | structlog | — |
 | Config | Pydantic + YAML | — |
 | CLI | Click | — |
+| Privacy / Audit | PrivacyGuard — PII masking + audit | — |
 | LLM Observability | — | Langfuse (`[observability]`) |
 | Cloud Storage | — | S3/GCS/BigQuery (`[cloud]`) |
 
@@ -164,6 +167,7 @@ DataEngineXError
 | AD7 | Project isolation via separate DuckDB files | Each project's `.dex/store.duckdb` is self-contained |
 | AD8 | Python 3.13+ | Full type parameter syntax, improved error messages |
 | AD9 | `ai/` for LLM/agents, `ml/` for classical ML | Clear domain separation |
+| AD10 | PrivacyGuard intercepts all outbound LLM calls | PII never leaves disk unmasked; audit trail is immutable |
 
 ## Ecosystem
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -37,8 +37,8 @@ This installs all Python dependencies and configures pre-commit hooks.
 
 ```bash
 # 1. Clone repo and create feature branch
-git clone https://github.com/TheDataEngineX/dataenginex.git
-cd dataenginex
+git clone https://github.com/TheDataEngineX/dex.git
+cd dex
 git checkout -b feat/issue-XXX-description dev
 
 # 3. Install Python deps & pre-commit hooks
@@ -208,5 +208,5 @@ uv run poe clean              # Remove caches and build artifacts
 - **Architecture**: See [architecture.md](./architecture.md)
 - **ADRs**: See [ADR-0001](./adr/0001-medallion-architecture.md) for architectural decisions
 - **Deployment**: See Deployment Runbook in the `infradex` repo
-- **Issues**: [GitHub Issues](https://github.com/TheDataEngineX/dataenginex/issues)
-- **Chat**: #dex-dev Slack channel
+- **Issues**: [GitHub Issues](https://github.com/TheDataEngineX/dex/issues)
+- **Discussions**: [GitHub Discussions](https://github.com/orgs/TheDataEngineX/discussions)

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -7,7 +7,7 @@ Get a DataEngineX pipeline running in under five minutes.
 ```bash
 pip install dataenginex
 # or from source:
-git clone https://github.com/TheDataEngineX/dataenginex && cd dataenginex
+git clone https://github.com/TheDataEngineX/dex && cd dex
 uv sync
 ```
 
@@ -59,7 +59,7 @@ layers = engine.warehouse_layers()
 tables = engine.warehouse_tables("silver")
 
 # Check history
-runs = engine.store.list_pipeline_runs(limit=10)
+runs = engine.store.get_pipeline_runs(None)[:10]
 ```
 
 ## 5. Run Examples
@@ -84,6 +84,51 @@ uv run poe test       # Full test suite
 uv run poe lint       # Lint with Ruff
 uv run poe typecheck  # mypy strict
 uv run poe check-all  # All of the above
+```
+
+## Spark and dbt sources
+
+Register a PySpark or dbt source with the `connection` dict:
+
+```python
+# PySpark source
+engine.add_source(
+    "ratings",
+    "spark",
+    connection={"master": "local[*]", "format": "parquet"},
+)
+
+# dbt source (runs `dbt run --select my_model`, reads the DuckDB target)
+engine.add_source(
+    "dbt_revenue",
+    "dbt",
+    connection={"project_dir": "/path/to/dbt_project", "model": "revenue", "target": "dev"},
+)
+```
+
+Install PySpark separately (`pip install pyspark`). dbt-core is CLI-only; install it globally.
+
+## PrivacyGuard
+
+Enable outbound-call interception and PII masking in `dex.yaml`:
+
+```yaml
+secops:
+  guard:
+    enabled: true
+    block_on_detect: false
+    strategies:
+      email: hash
+      ssn: redact
+  audit:
+    enabled: true
+    db_path: ".dex/audit.duckdb"
+```
+
+Access the audit log programmatically:
+
+```python
+events = engine.secops_audit.events   # list of AuditEvent
 ```
 
 ## Next Steps

--- a/poe_tasks.toml
+++ b/poe_tasks.toml
@@ -2,150 +2,153 @@
 executor.type = "uv"
 
 # ── Setup ─────────────────────────────────────────────────────────────────────
+
 [tool.poe.tasks.setup]
 shell = "uv sync --all-extras --all-groups && uvx pre-commit install"
-help = "One-step setup: install all dependency groups and pre-commit hooks"
+help  = "Install all dependency groups and pre-commit hooks"
 
-# ── Development ───────────────────────────────────────────────────────────────
 [tool.poe.tasks.dev]
-cmd = "python examples/ecommerce/run_all.py"
-help = "Run the ShopMetrics ecommerce example — exercises every dataenginex feature"
+cmd  = "python examples/ecommerce/run_all.py"
+help = "Run the ShopMetrics ecommerce example"
 
-# ── Code Quality ──────────────────────────────────────────────────────────────
+# ── Quality ───────────────────────────────────────────────────────────────────
+
 [tool.poe.tasks.lint]
 shell = "ruff check src/ tests/"
-help = "Lint: check for errors and style violations"
+help  = "Lint: check errors and style"
 
 [tool.poe.tasks.lint-fix]
 shell = "ruff check --fix src/ tests/ && ruff format src/ tests/"
-help = "Lint: auto-fix violations and format code"
+help  = "Lint: auto-fix violations and format"
 
 [tool.poe.tasks.format]
 shell = "ruff format src/ tests/"
-help = "Format code with ruff"
+help  = "Format with ruff"
 
 [tool.poe.tasks.imports-check]
 shell = "ruff check --select I src/ tests/"
-help = "Check import ordering and formatting"
+help  = "Check import ordering"
 
 [tool.poe.tasks.typecheck]
-cmd = "mypy src/dataenginex/ --config-file=pyproject.toml --no-incremental"
+cmd  = "mypy src/dataenginex/ --config-file=pyproject.toml --no-incremental"
 help = "Run mypy strict type checking"
-env = { UV_PYTHON = "3.13", UV_PROJECT_ENVIRONMENT = ".venv" }
+env  = {UV_PYTHON = "3.13", UV_PROJECT_ENVIRONMENT = ".venv"}
 
 [tool.poe.tasks.security]
-# uv run pip-audit audits the project venv directly — no pip required.
-# GHSA-5239-wwwm-4pmq: pygments ReDoS — no fix released yet, revisit when patch available.
-cmd = "uv run pip-audit --progress-spinner off --ignore-vuln GHSA-5239-wwwm-4pmq"
+cmd  = "uv run pip-audit --progress-spinner off --ignore-vuln GHSA-5239-wwwm-4pmq"
 help = "Audit dependencies for known vulnerabilities"
 
 [tool.poe.tasks.actionlint]
-shell = "if command -v actionlint >/dev/null 2>&1; then actionlint .github/workflows/*.yml; elif command -v docker >/dev/null 2>&1; then docker run --rm -v \"$PWD\":/repo -w /repo rhysd/actionlint:latest actionlint .github/workflows/*.yml; else echo 'actionlint not found — skipping'; fi"
+shell = """
+if command -v actionlint >/dev/null 2>&1; then
+  actionlint .github/workflows/*.yml
+elif command -v docker >/dev/null 2>&1; then
+  docker run --rm -v "$PWD":/repo -w /repo rhysd/actionlint:latest .github/workflows/*.yml
+else
+  echo 'actionlint not found — skipping'
+fi
+"""
 help = "Lint GitHub Actions workflow files"
 
 [tool.poe.tasks.quality]
 sequence = ["lint", "imports-check", "typecheck", "security"]
-help = "Run all code quality checks: lint, imports, types, security"
-
-[tool.poe.tasks.quality-fix]
-sequence = ["lint-fix"]
-help = "Auto-fix all fixable code quality issues (lint violations + formatting)"
+help     = "Run all quality checks: lint, imports, types, security"
 
 # ── Testing ───────────────────────────────────────────────────────────────────
+
 [tool.poe.tasks.test-core]
-cmd = "pytest tests/ -v --tb=short"
-help = "Internal: run all tests without dependency sync"
+cmd  = "pytest tests/ -v --tb=short"
+help = "Internal: run all tests (no sync)"
 
 [tool.poe.tasks.test]
 sequence = ["uv-sync", "test-core"]
-help = "Run all tests"
+help     = "Run all tests"
 
 [tool.poe.tasks.test-unit-core]
-cmd = "pytest tests/unit/ -v --tb=short"
-help = "Internal: run unit tests without dependency sync"
+cmd  = "pytest tests/unit/ -v --tb=short"
+help = "Internal: run unit tests (no sync)"
 
 [tool.poe.tasks.test-unit]
 sequence = ["uv-sync", "test-unit-core"]
-help = "Run unit tests only"
+help     = "Run unit tests"
 
 [tool.poe.tasks.test-integration-core]
-cmd = "pytest tests/integration/ -v --tb=short"
-help = "Internal: run integration tests without dependency sync"
+cmd  = "pytest tests/integration/ -v --tb=short"
+help = "Internal: run integration tests (no sync)"
 
 [tool.poe.tasks.test-integration]
 sequence = ["uv-sync", "test-integration-core"]
-help = "Run integration tests only"
+help     = "Run integration tests"
 
 [tool.poe.tasks.test-cov-core]
-cmd = "pytest tests/ -v --cov=dataenginex --cov-report=html --cov-report=xml:coverage.xml --cov-report=term-missing --cov-fail-under=80"
-help = "Internal: run tests with coverage without dependency sync (fails below 80%)"
+# COVERAGE_PROCESS_START ensures coverage starts before collection-time imports.
+env  = {COVERAGE_PROCESS_START = "pyproject.toml"}
+cmd  = "pytest tests/ -v --cov=dataenginex --cov-append --cov-report=html --cov-report=xml:coverage.xml --cov-report=term-missing --cov-fail-under=80"
+help = "Internal: tests with coverage, fails below 80% (no sync)"
 
 [tool.poe.tasks.test-cov]
 sequence = ["uv-sync", "test-cov-core"]
-help = "Run tests with coverage report (HTML + XML + terminal)"
+help     = "Run tests with coverage report (HTML + XML + terminal)"
 
 # ── Check Suites ──────────────────────────────────────────────────────────────
+
 [tool.poe.tasks.check-all-core]
 sequence = ["quality", "test-cov-core"]
-help = "Internal: run quality + coverage tests without dependency sync"
+help     = "Internal: quality + coverage (no sync)"
 
 [tool.poe.tasks.check-all]
 sequence = ["uv-sync", "check-all-core"]
-help = "Run full checks: quality gates + coverage tests"
-
-[tool.poe.tasks.check-all-managed]
-sequence = ["uv-sync-all", "check-all-core", "clean"]
-help = "Sync all deps, run full checks, then clean up"
+help     = "Full check: quality gates + coverage"
 
 # ── Docker ────────────────────────────────────────────────────────────────────
+
 [tool.poe.tasks.docker-build]
-cmd = "docker build -t dex:latest ."
+cmd  = "docker build -t dex:latest ."
 help = "Build Docker image"
 
 [tool.poe.tasks.docker-up]
-cmd = "docker compose up -d"
+cmd  = "docker compose up -d"
 help = "Start services with Docker Compose"
 
 [tool.poe.tasks.docker-down]
-cmd = "docker compose down"
+cmd  = "docker compose down"
 help = "Stop Docker Compose services"
 
 [tool.poe.tasks.docker-logs]
-cmd = "docker compose logs -f"
+cmd  = "docker compose logs -f"
 help = "View Docker Compose logs"
 
 # ── Utilities ─────────────────────────────────────────────────────────────────
+
 [tool.poe.tasks.version]
 shell = "python3 -c \"import tomllib; t=tomllib.load(open('pyproject.toml','rb')); print(t['project']['version'])\""
-help = "Show current package version"
+help  = "Show current package version"
 
 [tool.poe.tasks.clean]
-shell = "find . -type d -name __pycache__ -exec rm -rf {} + 2>/dev/null; find . -type f -name '*.pyc' -delete 2>/dev/null; rm -rf .pytest_cache .mypy_cache .ruff_cache dist build *.egg-info 2>/dev/null; echo 'Cache and artifacts cleaned'"
-help = "Remove cache and build artifacts"
+shell = "rm -rf .pytest_cache .mypy_cache .ruff_cache dist build htmlcov .coverage* && find . -type d -name __pycache__ -exec rm -rf {} + 2>/dev/null; echo 'cleaned'"
+help  = "Remove cache and build artifacts"
 
 [tool.poe.tasks.uv-lock]
-cmd = "uv lock"
+cmd  = "uv lock"
 help = "Resolve and write uv.lock"
 
 [tool.poe.tasks.uv-sync]
-cmd = "uv sync --group ml"
+cmd  = "uv sync --group ml"
 help = "Sync dependencies from uv.lock (includes ml group)"
-env = { UV_PROJECT_ENVIRONMENT = ".venv" }
+env  = {UV_PROJECT_ENVIRONMENT = ".venv"}
 
 [tool.poe.tasks.uv-sync-all]
-cmd = "uv sync --all-groups"
-help = "Sync all dependency groups from uv.lock"
-env = { UV_PROJECT_ENVIRONMENT = ".venv" }
+cmd  = "uv sync --all-groups"
+help = "Sync all dependency groups"
+env  = {UV_PROJECT_ENVIRONMENT = ".venv"}
 
-# ── Local-only: requires sibling ../.github/ repo (never run in CI) ──────────
 [tool.poe.tasks.sync-claude-settings]
 shell = """
 if [[ ! -d ../.github ]]; then
-  echo "ERROR: ../.github repo not found. Run from within the DataEngineX workspace." >&2
-  exit 1
+  echo "ERROR: ../.github repo not found" >&2; exit 1
 fi
 mkdir -p .claude
 cp ../.github/.claude/settings.json .claude/settings.json
-echo "✓ .claude/settings.json synced from .github/.claude/settings.json"
+echo "synced .claude/settings.json"
 """
-help = "Sync shared Claude Code settings from canonical .github/.claude/settings.json"
+help = "Sync Claude Code settings from ../.github/.claude/settings.json"

--- a/poe_tasks.toml
+++ b/poe_tasks.toml
@@ -81,9 +81,17 @@ sequence = ["uv-sync", "test-integration-core"]
 help     = "Run integration tests"
 
 [tool.poe.tasks.test-cov-core]
-# COVERAGE_PROCESS_START ensures coverage starts before collection-time imports.
+# `coverage run` starts measurement before any imports, ensuring module-level
+# code (Pydantic models, class defs, etc.) is correctly measured.  The env var
+# ensures subprocess coverage data is also captured (parallel mode).
 env  = {COVERAGE_PROCESS_START = "pyproject.toml"}
-cmd  = "pytest tests/ -v --cov=dataenginex --cov-append --cov-report=html --cov-report=xml:coverage.xml --cov-report=term-missing --cov-fail-under=80"
+shell = """
+  coverage run -m pytest tests/ -v && \
+  coverage combine && \
+  coverage html && \
+  coverage xml -o coverage.xml && \
+  coverage report --fail-under=80
+"""
 help = "Internal: tests with coverage, fails below 80% (no sync)"
 
 [tool.poe.tasks.test-cov]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -124,6 +124,8 @@ ignore_missing_imports = true
 [[tool.mypy.overrides]]
 module = [
     "dataenginex.data.quality.spark",
+    "dataenginex.data.connectors.spark",
+    "dataenginex.data.connectors.dbt",
     "dataenginex.ai.vectorstore",
     "dataenginex.lakehouse.storage",
     "dataenginex.ml.training",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -124,7 +124,7 @@ warn_unreachable = true
 no_implicit_optional = true
 
 [[tool.mypy.overrides]]
-module = ["structlog.*", "prometheus_client.*", "opentelemetry.*", "arq.*", "asyncpg.*", "qdrant_client.*"]
+module = ["structlog.*", "prometheus_client.*", "arq.*", "asyncpg.*", "qdrant_client.*"]
 ignore_missing_imports = true
 
 [[tool.mypy.overrides]]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,6 @@ dependencies = [
     "httpx>=0.28.1",
     "prometheus-client>=0.25.0",
     "structlog>=25.5.0",
-    # Data formats
     "pyarrow>=23.0.1",
 ]
 
@@ -31,24 +30,11 @@ cloud = [
     "google-cloud-storage>=3.10.1",
     "google-cloud-bigquery>=3.41.0",
 ]
-# NOTE: litellm is NOT declared here because it pins python-dotenv==1.0.1, which
-# conflicts with our python-dotenv>=1.2.1. Install separately for LiteLLMProvider:
-#     pip install 'litellm>=1.83.3' --no-deps
-# or manage via a dedicated venv. The provider is lazy-imported; DEX runs fine
-# without it.
-# Optional integrations — install only what you need:
-#   pip install 'dataenginex[postgres]'  — PostgresLineage, asyncpg-backed persistence
-#   pip install 'dataenginex[qdrant]'    — Qdrant vector store backend
-#   pip install 'dataenginex[queue]'     — ARQ async job queue (pulls in redis)
-postgres = [
-    "asyncpg>=0.31.0",
-]
-qdrant = [
-    "qdrant-client>=1.18.0",
-]
-queue = [
-    "arq>=0.28.0",
-]
+# litellm pins python-dotenv==1.0.1 — install separately if needed:
+#   pip install 'litellm>=1.83.3' --no-deps
+postgres = ["asyncpg>=0.31.0"]
+qdrant   = ["qdrant-client>=1.18.0"]
+queue    = ["arq>=0.28.0"]
 
 [dependency-groups]
 dev = [
@@ -82,11 +68,9 @@ ml = [
     "numpy>=2.4.4",
     "sentence-transformers>=5.5.1",
 ]
-# mlflow is in its own group — it pins pandas<3 which conflicts with notebook>=3.0
-# Install with: uv sync --group ml --group tracking
-tracking = [
-    "mlflow>=3.12.0",
-]
+# mlflow pins pandas<3 — install separately: uv sync --group ml --group tracking
+tracking = ["mlflow>=3.12.0"]
+
 [build-system]
 requires = ["hatchling>=1.29.0"]
 build-backend = "hatchling.build"
@@ -98,10 +82,11 @@ packages = ["src/dataenginex"]
 python-preference = "only-managed"
 default-groups = ["dev"]
 override-dependencies = [
-    # mlflow 3.12.0+ supports pandas 3.x but still has pandas<3 constraint
-    # Override to allow pandas>=3.0 (verified working via mlflow#22372)
+    # mlflow 3.12.0+ works with pandas 3.x despite its constraint
     "pandas>=3.0",
 ]
+
+# ── Ruff ─────────────────────────────────────────────────────────────────────
 
 [tool.ruff]
 line-length = 100
@@ -112,6 +97,8 @@ select = ["E", "F", "I", "B", "UP", "SIM", "C90"]
 
 [tool.ruff.lint.mccabe]
 max-complexity = 8
+
+# ── Mypy ─────────────────────────────────────────────────────────────────────
 
 [tool.mypy]
 python_version = "3.13"
@@ -124,66 +111,50 @@ warn_unreachable = true
 no_implicit_optional = true
 
 [[tool.mypy.overrides]]
-module = ["structlog.*", "prometheus_client.*", "arq.*", "asyncpg.*", "qdrant_client.*"]
+module = [
+    "structlog.*", "prometheus_client.*",
+    "arq.*", "asyncpg.*", "qdrant_client.*",
+    "boto3.*", "google.auth.*", "google.cloud.*", "google.api_core.*",
+    "pyarrow.*", "mlflow.*", "sentence_transformers.*",
+    "litellm.*", "pyspark.*",
+]
 ignore_missing_imports = true
 
+# These modules use optional imports that may or may not be installed
 [[tool.mypy.overrides]]
-module = ["boto3.*", "google.auth.*", "google.cloud.*", "google.api_core.*", "pyarrow.*"]
-ignore_missing_imports = true
+module = [
+    "dataenginex.data.quality.spark",
+    "dataenginex.ai.vectorstore",
+    "dataenginex.lakehouse.storage",
+    "dataenginex.ml.training",
+]
+warn_unused_ignores = false
 
-[[tool.mypy.overrides]]
-module = ["mlflow.*"]
-ignore_missing_imports = true
-
-[[tool.mypy.overrides]]
-module = ["sentence_transformers.*"]
-ignore_missing_imports = true
-
-[[tool.mypy.overrides]]
-module = ["litellm.*"]
-ignore_missing_imports = true
-
-[[tool.mypy.overrides]]
-module = ["pyspark.*"]
-ignore_missing_imports = true
-
-[[tool.mypy.overrides]]
-module = ["dataenginex.data.quality.spark"]
-warn_unused_ignores = false  # pyspark optional: ignore used in CI, unused when installed
-
-[[tool.mypy.overrides]]
-module = ["dataenginex.ai.vectorstore"]
-warn_unused_ignores = false  # sentence-transformers optional: ignore used in CI, unused when installed
-
-[[tool.mypy.overrides]]
-module = ["dataenginex.lakehouse.storage"]
-warn_unused_ignores = false  # pre-commit installs google-cloud-storage (ignore used), CI does not (ignore unused)
-
-[[tool.mypy.overrides]]
-module = ["dataenginex.ml.training"]
-warn_unused_ignores = false  # sklearn may be installed (import-untyped) or not (import-not-found) depending on env
+# ── Pytest ───────────────────────────────────────────────────────────────────
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 asyncio_mode = "auto"
 pythonpath = ["src"]
 filterwarnings = [
-    "error",                                          # Treat all warnings as errors by default
-    "ignore::DeprecationWarning:websockets\\.legacy",  # uvicorn uses deprecated websockets.legacy API
-    "ignore::DeprecationWarning:uvicorn\\.protocols",  # uvicorn imports deprecated WebSocketServerProtocol
-    "ignore:unclosed.*socket:ResourceWarning",         # Starlette TestClient GC timing
-    "ignore:unclosed event loop:ResourceWarning",      # Starlette TestClient GC timing
-    "ignore::pytest.PytestUnhandledThreadExceptionWarning",  # Qdrant compatibility check thread
-    "ignore::dataenginex.ai.runtime.sandbox.ExperimentalFeatureWarning",  # intentional once-per-process warning
+    "error",
+    "ignore::DeprecationWarning:websockets\\.legacy",
+    "ignore::DeprecationWarning:uvicorn\\.protocols",
+    "ignore:unclosed.*socket:ResourceWarning",
+    "ignore:unclosed event loop:ResourceWarning",
+    "ignore::pytest.PytestUnhandledThreadExceptionWarning",
+    "ignore::dataenginex.ai.runtime.sandbox.ExperimentalFeatureWarning",
 ]
+
+# ── Coverage ─────────────────────────────────────────────────────────────────
 
 [tool.coverage.run]
 branch = true
 source = ["dataenginex"]
-omit = [
-    # Requires a live MLflow server — not available in CI (same as S3/GCS integration tests)
-    "*/src/dataenginex/ml/mlflow_registry.py",
-]
+# parallel=true merges data from COVERAGE_PROCESS_START subprocesses so that
+# module-level code (imported at collection time) is correctly measured.
+parallel = true
+omit = ["*/src/dataenginex/ml/mlflow_registry.py"]
 
 [tool.coverage.report]
 show_missing = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -174,6 +174,7 @@ filterwarnings = [
     "ignore:unclosed.*socket:ResourceWarning",         # Starlette TestClient GC timing
     "ignore:unclosed event loop:ResourceWarning",      # Starlette TestClient GC timing
     "ignore::pytest.PytestUnhandledThreadExceptionWarning",  # Qdrant compatibility check thread
+    "ignore::dataenginex.ai.runtime.sandbox.ExperimentalFeatureWarning",  # intentional once-per-process warning
 ]
 
 [tool.coverage.run]

--- a/src/dataenginex/ai/agents/builtin.py
+++ b/src/dataenginex/ai/agents/builtin.py
@@ -15,7 +15,6 @@ import structlog
 
 from dataenginex.ai.agents import agent_registry
 from dataenginex.ai.tools import ToolRegistry, tool_registry
-from dataenginex.ai.tools.builtin import register_builtin_tools
 from dataenginex.core.interfaces import BaseAgentRuntime
 from dataenginex.middleware.domain_metrics import (
     ai_agent_iterations,
@@ -51,7 +50,6 @@ class BuiltinAgentRuntime(BaseAgentRuntime):
         self._max_iterations = max_iterations
         self._name = name
         self._history: list[dict[str, str]] = []
-        register_builtin_tools()
 
     async def run(self, message: str, **kwargs: Any) -> dict[str, Any]:
         """Execute agent with message and return structured result.
@@ -69,6 +67,12 @@ class BuiltinAgentRuntime(BaseAgentRuntime):
 
             if step_result.get("done", False):
                 response = str(step_result.get("response", ""))
+                # Strip raw ReAct trace: extract ANSWER: content if present
+                import re as _re
+
+                _ans = _re.search(r"ANSWER:\s*(.+)", response, _re.DOTALL | _re.IGNORECASE)
+                if _ans:
+                    response = _ans.group(1).strip()
                 self._history.append({"role": "assistant", "content": response})
                 ai_agent_iterations.labels(agent=self._name).observe(iterations)
                 return {"response": response, "iterations": iterations, "tool_calls": tool_calls}
@@ -85,22 +89,25 @@ class BuiltinAgentRuntime(BaseAgentRuntime):
 
     async def step(self, message: str, **kwargs: Any) -> dict[str, Any]:
         """Execute one reasoning step."""
+        import json
+        import re
+
         iteration = kwargs.get("iteration", 0)
 
         if self._llm is None:
-            # No LLM — just echo the message and mark done
             return {"done": True, "response": message, "iteration": iteration}
 
-        # Build prompt with tool descriptions
         tool_names = self._tools.list()
         tool_desc = ", ".join(tool_names) if tool_names else "none"
 
         prompt = (
-            f"{self._system_prompt}\n\n"
             f"Available tools: {tool_desc}\n\n"
-            f"To use a tool, respond with: TOOL: <name> ARGS: <json_args>\n"
-            f"To give a final answer, respond with: ANSWER: <your answer>\n\n"
-            f"User: {message}"
+            f"You MUST respond in EXACTLY one of these two formats — no other text:\n"
+            f'  TOOL: <tool_name>\n  ARGS: {{"key": "value"}}\n\n'
+            f"  ANSWER: <your final answer>\n\n"
+            f"Example tool call:\n"
+            f'  TOOL: query\n  ARGS: {{"sql": "SELECT * FROM gold_top_movies LIMIT 3"}}\n\n'
+            f"User request: {message}"
         )
 
         from dataenginex.ai.llm import ChatMessage
@@ -112,33 +119,34 @@ class BuiltinAgentRuntime(BaseAgentRuntime):
         ]
 
         response = self._llm.chat(messages)
-        text = response.text
+        text = response.text.strip()
 
-        # Parse response for tool calls
-        if text.startswith("TOOL:"):
-            return self._handle_tool_call(text, iteration)
+        # Robust: search for TOOL: pattern anywhere in text
+        tool_match = re.search(
+            r"TOOL:\s*(\w+)\s*\n?\s*ARGS:\s*(\{.*?\})",
+            text,
+            re.DOTALL | re.IGNORECASE,
+        )
+        if tool_match:
+            tool_name = tool_match.group(1).strip()
+            args_str = tool_match.group(2).strip()
+            try:
+                args = json.loads(args_str)
+            except json.JSONDecodeError:
+                args = {}
+            return self._handle_tool_call_parsed(tool_name, args, iteration)
 
-        # Final answer
-        answer = text.removeprefix("ANSWER:").strip() if text.startswith("ANSWER:") else text
+        # Final answer — strip ANSWER: prefix if present
+        answer = re.sub(r"^ANSWER:\s*", "", text, flags=re.IGNORECASE).strip()
         return {"done": True, "response": answer, "iteration": iteration}
 
-    def _handle_tool_call(
+    def _handle_tool_call_parsed(
         self,
-        text: str,
+        tool_name: str,
+        args: dict[str, Any],
         iteration: int,
     ) -> dict[str, Any]:
-        """Parse and execute a tool call."""
-        import json
-
-        parts = text.split("ARGS:", 1)
-        tool_name = parts[0].removeprefix("TOOL:").strip()
-        args_str = parts[1].strip() if len(parts) > 1 else "{}"
-
-        try:
-            args = json.loads(args_str)
-        except json.JSONDecodeError:
-            args = {}
-
+        """Execute a parsed tool call."""
         try:
             result = self._tools.call(tool_name, **args)
             observation = f"Tool '{tool_name}' returned: {result}"
@@ -150,7 +158,6 @@ class BuiltinAgentRuntime(BaseAgentRuntime):
         self._history.append(
             {"role": "assistant", "content": f"[tool: {tool_name}] {observation}"},
         )
-
         return {
             "done": False,
             "tool": tool_name,
@@ -158,6 +165,23 @@ class BuiltinAgentRuntime(BaseAgentRuntime):
             "observation": observation,
             "iteration": iteration,
         }
+
+    def _handle_tool_call(
+        self,
+        text: str,
+        iteration: int,
+    ) -> dict[str, Any]:
+        """Parse and execute a tool call from raw TOOL:/ARGS: text."""
+        import json
+
+        parts = text.split("ARGS:", 1)
+        tool_name = parts[0].removeprefix("TOOL:").strip()
+        args_str = parts[1].strip() if len(parts) > 1 else "{}"
+        try:
+            args = json.loads(args_str)
+        except json.JSONDecodeError:
+            args = {}
+        return self._handle_tool_call_parsed(tool_name, args, iteration)
 
     @property
     def history(self) -> list[dict[str, str]]:

--- a/src/dataenginex/ai/routing/__init__.py
+++ b/src/dataenginex/ai/routing/__init__.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from dataenginex.ai.routing.guarded import GuardedProvider
 from dataenginex.ai.routing.router import BaseProvider, ModelRouter
 
-__all__ = ["BaseProvider", "ModelRouter"]
+__all__ = ["BaseProvider", "GuardedProvider", "ModelRouter"]

--- a/src/dataenginex/ai/routing/guarded.py
+++ b/src/dataenginex/ai/routing/guarded.py
@@ -1,0 +1,80 @@
+"""GuardedProvider — wrap a BaseProvider so every outbound call is PII-guarded.
+
+Decorator-style wrapper. The inner provider's ``generate`` is invoked with
+the guard's masked prompt; on a block the wrapper raises
+:exc:`~dataenginex.secops.guard.PrivacyBlocked` instead of contacting the
+remote service at all.
+
+Example::
+
+    from dataenginex.ai.routing.openai import OpenAIProvider
+    from dataenginex.ai.routing.guarded import GuardedProvider
+    from dataenginex.secops import PrivacyGuard
+
+    guard = PrivacyGuard()
+    provider = GuardedProvider(OpenAIProvider(api_key="..."), guard, target="openai")
+    answer = provider.generate("Email me at alice@example.com")
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from dataenginex.ai.routing.router import BaseProvider
+from dataenginex.secops.guard import PrivacyBlocked, PrivacyGuard
+
+__all__ = ["GuardedProvider"]
+
+
+class GuardedProvider(BaseProvider):
+    """A :class:`BaseProvider` whose ``generate`` runs through a :class:`PrivacyGuard`.
+
+    The wrapper preserves the inner provider's full ``**kwargs`` API; only
+    the prompt is transformed before being passed through.
+
+    Parameters:
+        inner: The provider whose calls should be guarded.
+        guard: The guard instance to apply.
+        target: Logical name for the inner provider (e.g. ``"openai"``,
+            ``"anthropic"``). Used by the guard's local-bypass check and
+            audit logs. Defaults to the inner class name with ``"provider"``
+            stripped, lowercased.
+    """
+
+    def __init__(
+        self,
+        inner: BaseProvider,
+        guard: PrivacyGuard,
+        target: str = "",
+    ) -> None:
+        self._inner = inner
+        self._guard = guard
+        self._target = target or self._derive_target(inner)
+
+    @property
+    def inner(self) -> BaseProvider:
+        """The wrapped provider (read-only)."""
+        return self._inner
+
+    @property
+    def target(self) -> str:
+        """The provider name used for guard decisions and audit logs."""
+        return self._target
+
+    def generate(self, prompt: str, **kwargs: Any) -> str:
+        """Run the guard, then delegate to the wrapped provider.
+
+        Raises:
+            PrivacyBlocked: When the guard's ``block_on_detect`` rejected
+                the call. The inner provider is *not* invoked in that case.
+        """
+        result = self._guard.process(prompt, target=self._target)
+        if result.blocked:
+            raise PrivacyBlocked(target=self._target, detections=result.detections)
+        return self._inner.generate(result.safe_prompt, **kwargs)
+
+    @staticmethod
+    def _derive_target(inner: BaseProvider) -> str:
+        """Best-effort target name from the inner provider's class name."""
+        name = type(inner).__name__.lstrip("_").lower()
+        return name.removesuffix("provider") or name

--- a/src/dataenginex/ai/runtime/sandbox.py
+++ b/src/dataenginex/ai/runtime/sandbox.py
@@ -71,6 +71,7 @@ def _warn_experimental_once() -> None:
         stacklevel=3,
     )
 
+
 _DEFAULT_TIMEOUT = 30
 _DEFAULT_MEMORY_MB = 256
 _DEFAULT_CPU_S = 30

--- a/src/dataenginex/ai/tools/builtin.py
+++ b/src/dataenginex/ai/tools/builtin.py
@@ -1,17 +1,27 @@
 """Built-in tools for agent runtimes.
 
-Provides tools that agents can invoke: SQL queries, pipeline status, etc.
+Provides tools that agents can invoke: SQL queries, ML inference,
+semantic search, pipeline status, etc.
 """
 
 from __future__ import annotations
 
-from typing import Any
+import contextlib
+from collections.abc import Callable
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
 
 import structlog
 
 from dataenginex.ai.tools import ToolSpec, tool_registry
 
+if TYPE_CHECKING:
+    pass
+
 logger = structlog.get_logger()
+
+
+# ── SQL / lakehouse ────────────────────────────────────────────────────────────
 
 
 def _query_sql(sql: str, database: str = ":memory:") -> list[dict[str, Any]]:
@@ -21,31 +31,182 @@ def _query_sql(sql: str, database: str = ":memory:") -> list[dict[str, Any]]:
     conn = duckdb.connect(database)
     try:
         result = conn.execute(sql)
-        columns = [desc[0] for desc in result.description]
+        description = result.description or []
+        if not description:
+            return []
+        columns = [desc[0] for desc in description]
         return [dict(zip(columns, row, strict=True)) for row in result.fetchall()]
     finally:
         conn.close()
 
 
+def _make_lakehouse_query(lakehouse_dir: Path) -> Callable[[str], list[dict[str, Any]]]:
+    """Return a query function that pre-registers all lakehouse parquet files as views."""
+
+    def _query_with_lakehouse(sql: str) -> list[dict[str, Any]]:
+        import duckdb
+
+        conn = duckdb.connect(":memory:")
+        try:
+            for layer in ("bronze", "silver", "gold"):
+                layer_path = lakehouse_dir / layer
+                if not layer_path.exists():
+                    continue
+                for pf in sorted(layer_path.glob("*.parquet")):
+                    safe = str(pf).replace("'", "''")
+                    with contextlib.suppress(Exception):
+                        conn.execute(
+                            f"CREATE OR REPLACE VIEW {pf.stem}"
+                            f" AS SELECT * FROM read_parquet('{safe}')"
+                        )
+            result = conn.execute(sql)
+            description = result.description or []
+            if not description:
+                return []
+            columns = [desc[0] for desc in description]
+            return [dict(zip(columns, row, strict=True)) for row in result.fetchall()]
+        finally:
+            conn.close()
+
+    return _query_with_lakehouse
+
+
+# ── ML inference ───────────────────────────────────────────────────────────────
+
+
+def _make_predict(
+    models_dir: Path,
+    registry_path: Path | None = None,
+) -> Callable[..., Any]:
+    """Return a predict function that loads and calls sklearn models by name.
+
+    Looks up the model artifact path from registry.json (if present) or falls
+    back to ``<models_dir>/<model_name>_v*.pkl`` glob.
+    """
+
+    def _predict(model_name: str, features: dict[str, Any]) -> Any:
+        import json
+        import pickle
+
+        artifact: Path | None = None
+
+        # Try registry first
+        reg = registry_path or models_dir / "registry.json"
+        if reg.exists():
+            with contextlib.suppress(Exception):
+                data = json.loads(reg.read_text())
+                versions = data.get(model_name, [])
+                if versions:
+                    # Prefer production stage, else latest
+                    prod = [v for v in versions if v.get("stage") == "production"]
+                    entry = (prod or versions)[-1]
+                    artifact = Path(entry["artifact_path"])
+
+        # Fallback: glob for <model_name>_v*.pkl
+        if artifact is None or not artifact.exists():
+            candidates = sorted(models_dir.glob(f"{model_name}_v*.pkl"))
+            if candidates:
+                artifact = candidates[-1]
+
+        if artifact is None or not artifact.exists():
+            available = [p.stem.rsplit("_v", 1)[0] for p in models_dir.glob("*_v*.pkl")]
+            return {"error": f"Model '{model_name}' not found. Available: {list(set(available))}"}
+
+        try:
+            with artifact.open("rb") as f:
+                model = pickle.load(f)  # noqa: S301
+
+            import pandas as pd  # type: ignore[import-untyped]
+
+            df = pd.DataFrame([features])
+            prediction = model.predict(df)
+            result: Any = prediction.tolist() if hasattr(prediction, "tolist") else list(prediction)
+            return {"model": model_name, "prediction": result, "artifact": artifact.name}
+        except Exception as exc:
+            return {"error": f"Prediction failed: {exc}"}
+
+    return _predict
+
+
+# ── Semantic search ────────────────────────────────────────────────────────────
+
+
+def _make_search_similar(
+    vector_store: Any,
+    embed_fn: Any | None = None,
+) -> Callable[..., list[dict[str, Any]]]:
+    """Return a semantic search function backed by the shared vector store."""
+
+    def _search_similar(query: str, top_k: int = 5) -> list[dict[str, Any]]:
+        try:
+            from dataenginex.ai.vectorstore import RAGPipeline
+
+            rag = RAGPipeline(store=vector_store, embed_fn=embed_fn, dimension=384)
+            results = rag.query(query, top_k=top_k)
+            if not results:
+                return [{"info": "Vector store is empty — run a gold pipeline to populate it."}]
+            return [
+                {
+                    "id": r.document.id,
+                    "text": r.document.text,
+                    "score": round(r.score, 4),
+                    **r.document.metadata,
+                }
+                for r in results
+            ]
+        except Exception as exc:
+            return [{"error": str(exc)}]
+
+    return _search_similar
+
+
+# ── Builtins ───────────────────────────────────────────────────────────────────
+
+
 def _list_tools() -> list[str]:
-    """List all available tools."""
     return tool_registry.list()
 
 
 def _echo(message: str) -> str:
-    """Echo a message back (useful for testing)."""
     return message
 
 
-def register_builtin_tools() -> None:
-    """Register all built-in tools."""
-    builtins = [
-        ToolSpec(
-            name="query",
-            description="Execute a SQL query via DuckDB",
-            fn=_query_sql,
-            parameters={"sql": "str", "database": "str (optional)"},
-        ),
+# ── Registration ───────────────────────────────────────────────────────────────
+
+
+def register_builtin_tools(
+    lakehouse_dir: Path | None = None,
+    models_dir: Path | None = None,
+    vector_store: Any = None,
+    embed_fn: Any | None = None,
+) -> None:
+    """Register all built-in tools.
+
+    Args:
+        lakehouse_dir: When provided, the ``query`` tool pre-registers every
+            parquet file in bronze/silver/gold as a DuckDB view.
+        models_dir: When provided, registers a ``predict`` tool that loads
+            sklearn models from the model registry.
+        vector_store: When provided, registers a ``search_similar`` tool for
+            semantic search over embedded lakehouse documents.
+        embed_fn: Embedding callable for ``search_similar``. Falls back to
+            hash-based embedding when ``None``.
+    """
+    query_fn: Callable[..., Any]
+    if lakehouse_dir:
+        query_fn = _make_lakehouse_query(lakehouse_dir)
+        query_desc = (
+            "Execute a SQL query against the lakehouse. "
+            "All bronze/silver/gold tables are pre-registered as views."
+        )
+        query_params: dict[str, str] = {"sql": "str"}
+    else:
+        query_fn = _query_sql
+        query_desc = "Execute a SQL query via DuckDB"
+        query_params = {"sql": "str", "database": "str (optional)"}
+
+    builtins: list[ToolSpec] = [
+        ToolSpec(name="query", description=query_desc, fn=query_fn, parameters=query_params),
         ToolSpec(
             name="list_tools",
             description="List all available tools",
@@ -59,6 +220,40 @@ def register_builtin_tools() -> None:
             parameters={"message": "str"},
         ),
     ]
+
+    if models_dir and models_dir.exists():
+        registry_path = models_dir / "registry.json"
+        predict_fn = _make_predict(models_dir, registry_path if registry_path.exists() else None)
+        builtins.append(
+            ToolSpec(
+                name="predict",
+                description=(
+                    "Run ML model inference. "
+                    "Args: model_name (str), features (dict of feature→value). "
+                    "Available models: "
+                    + ", ".join(
+                        p.stem.rsplit("_v", 1)[0] for p in sorted(models_dir.glob("*_v*.pkl"))
+                    )
+                ),
+                fn=predict_fn,
+                parameters={"model_name": "str", "features": "dict"},
+            )
+        )
+
+    if vector_store is not None:
+        search_fn = _make_search_similar(vector_store, embed_fn)
+        builtins.append(
+            ToolSpec(
+                name="search_similar",
+                description=(
+                    "Semantic similarity search over the movie catalog. "
+                    "Finds movies similar to a natural-language query. "
+                    "Args: query (str), top_k (int, default 5)."
+                ),
+                fn=search_fn,
+                parameters={"query": "str", "top_k": "int (optional, default 5)"},
+            )
+        )
+
     for spec in builtins:
-        if spec.name not in tool_registry._tools:
-            tool_registry.register(spec)
+        tool_registry.register(spec)

--- a/src/dataenginex/cli/main.py
+++ b/src/dataenginex/cli/main.py
@@ -93,9 +93,11 @@ def version() -> None:
 
 
 from dataenginex.cli.run import run  # noqa: E402
+from dataenginex.cli.secops import secops  # noqa: E402
 from dataenginex.cli.train import train  # noqa: E402
 
 dex.add_command(run)
+dex.add_command(secops)
 dex.add_command(train)
 
 if __name__ == "__main__":

--- a/src/dataenginex/cli/secops.py
+++ b/src/dataenginex/cli/secops.py
@@ -82,9 +82,7 @@ def scan(text: str, config_path: str, target: str) -> None:
     result = guard.process(text, target=target)
 
     if result.bypassed_local:
-        click.echo(
-            click.style(f"⊘  Bypassed — '{target}' is a local provider", fg="yellow")
-        )
+        click.echo(click.style(f"⊘  Bypassed — '{target}' is a local provider", fg="yellow"))
         return
 
     if result.detections:

--- a/src/dataenginex/cli/secops.py
+++ b/src/dataenginex/cli/secops.py
@@ -1,0 +1,127 @@
+"""`dex secops` — inspect and test the PrivacyGuard from the command line.
+
+Subcommands::
+
+    dex secops status            # show guard config from the loaded dex.yaml
+    dex secops scan "some text"  # run PII detection and show matches
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import click
+
+_DEFAULT_CONFIG = "dex.yaml"
+
+
+@click.group()
+def secops() -> None:
+    """SecOps — PrivacyGuard inspection and PII scanning."""
+
+
+@secops.command()
+@click.option("--config", "config_path", default=_DEFAULT_CONFIG, help="dex.yaml path")
+def status(config_path: str) -> None:
+    """Show the PrivacyGuard configuration from dex.yaml."""
+    from dataenginex.config import load_config
+
+    cfg = load_config(Path(config_path))
+    g = cfg.secops.guard
+    a = cfg.secops.audit
+
+    _section("Guard")
+    _row("Enabled", _yn(g.enabled))
+    _row("Block on detect", _yn(g.block_on_detect))
+    _row("Allow local bypass", _yn(g.allow_local))
+    _row("Log all outbound", _yn(g.log_all_outbound))
+    _row(
+        "Local targets",
+        ", ".join(sorted(g.local_targets)) if g.local_targets else "(none)",
+    )
+
+    if g.strategies:
+        click.echo()
+        _section("PII Strategies")
+        for pii_type, strategy in sorted(g.strategies.items()):
+            _row(pii_type, strategy)
+    else:
+        _row("PII strategies", "default (REDACT all)")
+
+    click.echo()
+    _section("Audit Logger")
+    _row("Enabled", _yn(a.enabled))
+    if a.enabled:
+        _row("DB path", a.db_path if a.db_path else ":memory: (no persistence)")
+
+    click.echo()
+
+
+@secops.command()
+@click.argument("text")
+@click.option("--config", "config_path", default=_DEFAULT_CONFIG, help="dex.yaml path")
+@click.option(
+    "--target",
+    default="openai",
+    show_default=True,
+    help="Provider target name (affects local-bypass logic).",
+)
+def scan(text: str, config_path: str, target: str) -> None:
+    """Scan TEXT for PII using the guard configured in dex.yaml.
+
+    Prints each match (type, confidence, matched value) and shows the masked
+    output the guard would send to the provider.
+    """
+    from dataenginex.config import load_config
+    from dataenginex.secops import PrivacyGuard, PrivacyGuardConfig
+
+    cfg = load_config(Path(config_path))
+    guard_cfg = PrivacyGuardConfig.from_dict(cfg.secops.guard.model_dump())
+    guard = PrivacyGuard(config=guard_cfg)
+
+    result = guard.process(text, target=target)
+
+    if result.bypassed_local:
+        click.echo(
+            click.style(f"⊘  Bypassed — '{target}' is a local provider", fg="yellow")
+        )
+        return
+
+    if result.detections:
+        _section(f"Detections ({len(result.detections)})")
+        for m in result.detections:
+            conf = f"{m.confidence:.0%}" if m.confidence is not None else ""
+            click.echo(
+                f"  {click.style(m.pii_type.value, fg='red', bold=True):<20}"
+                f"  {conf:<8}"
+                f"  {m.value!r}"
+            )
+        click.echo()
+        if result.blocked:
+            click.echo(click.style("✗  BLOCKED — prompt would not be sent", fg="red", bold=True))
+        else:
+            _section("Masked output")
+            click.echo(f"  {result.safe_prompt}")
+    else:
+        click.echo(click.style("✓  No PII detected", fg="green"))
+        click.echo(f"  {text}")
+
+    click.echo()
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _section(title: str) -> None:
+    click.echo(click.style(f"  {title}", bold=True))
+    click.echo(click.style("  " + "─" * (len(title) + 2), fg="bright_black"))
+
+
+def _row(key: str, value: str) -> None:
+    click.echo(f"    {key:<28}{value}")
+
+
+def _yn(flag: bool) -> str:
+    return click.style("yes", fg="green") if flag else click.style("no", fg="red")

--- a/src/dataenginex/config/loader.py
+++ b/src/dataenginex/config/loader.py
@@ -180,6 +180,34 @@ def _validate_registries(config: DexConfig) -> list[str]:
     return warnings
 
 
+def _validate_secops(config: DexConfig) -> list[str]:
+    """Validate secops.guard strategy entries against known enums.
+
+    Returns hard errors (not warnings) because an unknown PII type or masking
+    strategy will raise at engine init time — better to surface them early via
+    ``dex validate``.
+    """
+    from dataenginex.secops.masking import MaskingStrategy
+    from dataenginex.secops.pii import PIIType
+
+    valid_pii = {t.value for t in PIIType}
+    valid_strategies = {s.value for s in MaskingStrategy}
+    errors: list[str] = []
+
+    for raw_type, raw_strategy in config.secops.guard.strategies.items():
+        if raw_type not in valid_pii:
+            errors.append(
+                f"secops.guard.strategies: unknown PII type '{raw_type}' "
+                f"(valid: {sorted(valid_pii)})"
+            )
+        if raw_strategy not in valid_strategies:
+            errors.append(
+                f"secops.guard.strategies['{raw_type}']: unknown masking strategy "
+                f"'{raw_strategy}' (valid: {sorted(valid_strategies)})"
+            )
+    return errors
+
+
 def validate_config(config: DexConfig) -> list[str]:
     """Run cross-reference validation on a loaded config.
 
@@ -189,6 +217,7 @@ def validate_config(config: DexConfig) -> list[str]:
     """
     errors = _validate_pipelines(config)
     errors.extend(_validate_registries(config))
+    errors.extend(_validate_secops(config))
 
     if errors:
         logger.warning("config validation issues", count=len(errors))

--- a/src/dataenginex/config/schema.py
+++ b/src/dataenginex/config/schema.py
@@ -222,11 +222,41 @@ class AuditConfig(BaseModel):
     destination: str = "file"  # file, database
 
 
+class GuardConfig(BaseModel):
+    """Outbound LLM call guard (``PrivacyGuard``) configuration.
+
+    Wraps every external LLM provider call with PII detection and either
+    masking or blocking. Local providers (Ollama, etc.) bypass guarding
+    by default since their data never leaves the machine.
+
+    Attributes:
+        enabled: Master switch. When ``False`` the guard logs once and
+            passes all prompts through unchanged.
+        allow_local: When ``True``, prompts to local providers bypass
+            scanning. Disable to scan local calls too (e.g. for audit-only).
+        block_on_detect: When ``True``, prompts containing PII raise
+            ``PrivacyBlocked`` instead of being masked.
+        log_all_outbound: Emit a structlog entry for every outbound call.
+        strategies: Map of PII type → masking strategy, e.g.
+            ``{"email": "hash", "ssn": "redact"}``. PII types absent from
+            this map fall back to the masker's default (``REDACT``).
+        local_targets: Provider names treated as local (bypass scan).
+    """
+
+    enabled: bool = True
+    allow_local: bool = True
+    block_on_detect: bool = False
+    log_all_outbound: bool = True
+    strategies: dict[str, str] = Field(default_factory=dict)
+    local_targets: list[str] = Field(default_factory=lambda: ["ollama", "local"])
+
+
 class SecopsConfig(BaseModel):
     """Security operations configuration."""
 
     pii: PiiConfig = Field(default_factory=PiiConfig)
     audit: AuditConfig = Field(default_factory=AuditConfig)
+    guard: GuardConfig = Field(default_factory=GuardConfig)
 
 
 # --- Observability ---

--- a/src/dataenginex/config/schema.py
+++ b/src/dataenginex/config/schema.py
@@ -216,10 +216,21 @@ class PiiConfig(BaseModel):
 
 
 class AuditConfig(BaseModel):
-    """Audit logging configuration."""
+    """Audit logging configuration.
+
+    Attributes:
+        enabled: Master switch. When ``True`` a :class:`~dataenginex.secops.AuditLogger`
+            is created and attached to the :class:`~dataenginex.secops.PrivacyGuard`
+            so every PII detection/masking event is persisted.
+        db_path: DuckDB database path for the audit log.  Leave empty (default)
+            for in-memory-only logging (data lost on restart). Set to a relative
+            path (e.g. ``"secops_audit.db"``) and it is resolved under the
+            project's ``.dex/`` directory; use an absolute path for a custom
+            location.
+    """
 
     enabled: bool = False
-    destination: str = "file"  # file, database
+    db_path: str = ""  # empty → :memory: (no persistence)
 
 
 class GuardConfig(BaseModel):

--- a/src/dataenginex/data/__init__.py
+++ b/src/dataenginex/data/__init__.py
@@ -22,6 +22,7 @@ from __future__ import annotations
 from dataenginex.data.connectors import connector_registry
 from dataenginex.data.connectors.csv import CsvConnector
 from dataenginex.data.connectors.duckdb import DuckDBConnector
+from dataenginex.data.connectors.parquet import ParquetConnector
 
 # Legacy API (backward-compatible)
 from dataenginex.data.connectors.legacy import (
@@ -41,6 +42,7 @@ __all__ = [
     # New
     "CsvConnector",
     "DuckDBConnector",
+    "ParquetConnector",
     "PipelineResult",
     "PipelineRunner",
     "QualityResult",

--- a/src/dataenginex/data/__init__.py
+++ b/src/dataenginex/data/__init__.py
@@ -22,7 +22,6 @@ from __future__ import annotations
 from dataenginex.data.connectors import connector_registry
 from dataenginex.data.connectors.csv import CsvConnector
 from dataenginex.data.connectors.duckdb import DuckDBConnector
-from dataenginex.data.connectors.parquet import ParquetConnector
 
 # Legacy API (backward-compatible)
 from dataenginex.data.connectors.legacy import (
@@ -32,6 +31,7 @@ from dataenginex.data.connectors.legacy import (
     FileConnector,
     RestConnector,
 )
+from dataenginex.data.connectors.parquet import ParquetConnector
 from dataenginex.data.pipeline.runner import PipelineResult, PipelineRunner
 from dataenginex.data.profiler import ColumnProfile, DataProfiler, ProfileReport
 from dataenginex.data.quality.gates import QualityResult, check_quality

--- a/src/dataenginex/data/connectors/__init__.py
+++ b/src/dataenginex/data/connectors/__init__.py
@@ -10,6 +10,7 @@ connector_registry: BackendRegistry[BaseConnector] = BackendRegistry("connector"
 
 # Auto-register built-in connector backends
 from dataenginex.data.connectors.csv import CsvConnector  # noqa: E402, F401
+from dataenginex.data.connectors.dbt import DbtConnector  # noqa: E402, F401
 from dataenginex.data.connectors.duckdb import DuckDBConnector  # noqa: E402, F401
 
 # Re-export legacy connector classes for backward compatibility
@@ -21,11 +22,14 @@ from dataenginex.data.connectors.legacy import (  # noqa: E402
     RestConnector,
 )
 from dataenginex.data.connectors.parquet import ParquetConnector  # noqa: E402, F401
+from dataenginex.data.connectors.spark import SparkConnector  # noqa: E402, F401
 
 __all__ = [
     # New
     "BaseConnector",
     "connector_registry",
+    "DbtConnector",
+    "SparkConnector",
     # Legacy
     "ConnectorStatus",
     "DataConnector",

--- a/src/dataenginex/data/connectors/__init__.py
+++ b/src/dataenginex/data/connectors/__init__.py
@@ -9,9 +9,8 @@ from dataenginex.core.registry import BackendRegistry
 connector_registry: BackendRegistry[BaseConnector] = BackendRegistry("connector")
 
 # Auto-register built-in connector backends
-from dataenginex.data.connectors.csv import CsvConnector  # noqa: F401
-from dataenginex.data.connectors.duckdb import DuckDBConnector  # noqa: F401
-from dataenginex.data.connectors.parquet import ParquetConnector  # noqa: F401
+from dataenginex.data.connectors.csv import CsvConnector  # noqa: E402, F401
+from dataenginex.data.connectors.duckdb import DuckDBConnector  # noqa: E402, F401
 
 # Re-export legacy connector classes for backward compatibility
 from dataenginex.data.connectors.legacy import (  # noqa: E402
@@ -21,6 +20,7 @@ from dataenginex.data.connectors.legacy import (  # noqa: E402
     FileConnector,
     RestConnector,
 )
+from dataenginex.data.connectors.parquet import ParquetConnector  # noqa: E402, F401
 
 __all__ = [
     # New

--- a/src/dataenginex/data/connectors/__init__.py
+++ b/src/dataenginex/data/connectors/__init__.py
@@ -8,6 +8,11 @@ from dataenginex.core.registry import BackendRegistry
 # New registry-based connector system
 connector_registry: BackendRegistry[BaseConnector] = BackendRegistry("connector")
 
+# Auto-register built-in connector backends
+from dataenginex.data.connectors.csv import CsvConnector  # noqa: F401
+from dataenginex.data.connectors.duckdb import DuckDBConnector  # noqa: F401
+from dataenginex.data.connectors.parquet import ParquetConnector  # noqa: F401
+
 # Re-export legacy connector classes for backward compatibility
 from dataenginex.data.connectors.legacy import (  # noqa: E402
     ConnectorStatus,

--- a/src/dataenginex/data/connectors/_utils.py
+++ b/src/dataenginex/data/connectors/_utils.py
@@ -1,0 +1,17 @@
+"""Shared utilities for data connectors."""
+
+from __future__ import annotations
+
+from typing import Any
+
+NOT_CONNECTED: str = "Not connected — call connect() first"
+
+
+def rows_to_dicts(cursor: Any) -> list[dict[str, Any]]:
+    """Convert a DBAPI cursor result to a list of dicts.
+
+    Uses ``cursor.description`` for column names and ``cursor.fetchall()``
+    for row data.  Compatible with DuckDB and any DBAPI-2 cursor.
+    """
+    columns: list[str] = [desc[0] for desc in cursor.description]
+    return [dict(zip(columns, row, strict=True)) for row in cursor.fetchall()]

--- a/src/dataenginex/data/connectors/csv.py
+++ b/src/dataenginex/data/connectors/csv.py
@@ -14,6 +14,7 @@ import structlog
 
 from dataenginex.core.interfaces import BaseConnector
 from dataenginex.data.connectors import connector_registry
+from dataenginex.data.connectors._utils import NOT_CONNECTED, rows_to_dicts
 
 logger = structlog.get_logger()
 
@@ -49,8 +50,7 @@ class CsvConnector(BaseConnector):
         **kwargs: Any,
     ) -> list[dict[str, Any]]:
         if self._conn is None:
-            msg = "Not connected — call connect() first"
-            raise RuntimeError(msg)
+            raise RuntimeError(NOT_CONNECTED)
 
         # If path itself is a file, use it directly; otherwise treat as directory
         if self._path.is_file():
@@ -72,13 +72,11 @@ class CsvConnector(BaseConnector):
 
         safe_path = str(filepath).replace("'", "''")
         result = self._conn.execute(f"SELECT * FROM read_csv_auto('{safe_path}')")
-        columns = [desc[0] for desc in result.description]
-        return [dict(zip(columns, row, strict=True)) for row in result.fetchall()]
+        return rows_to_dicts(result)
 
     def write(self, data: Any, *, table: str = "output.csv", **kwargs: Any) -> None:
         if self._conn is None:
-            msg = "Not connected — call connect() first"
-            raise RuntimeError(msg)
+            raise RuntimeError(NOT_CONNECTED)
         import pyarrow as pa
         import pyarrow.csv as pcsv
 

--- a/src/dataenginex/data/connectors/csv.py
+++ b/src/dataenginex/data/connectors/csv.py
@@ -10,6 +10,8 @@ from pathlib import Path
 from typing import Any
 
 import duckdb
+import pyarrow as pa
+import pyarrow.csv as pcsv
 import structlog
 
 from dataenginex.core.interfaces import BaseConnector
@@ -77,8 +79,6 @@ class CsvConnector(BaseConnector):
     def write(self, data: Any, *, table: str = "output.csv", **kwargs: Any) -> None:
         if self._conn is None:
             raise RuntimeError(NOT_CONNECTED)
-        import pyarrow as pa
-        import pyarrow.csv as pcsv
 
         filepath = self._path / table
         if isinstance(data, list):
@@ -89,7 +89,7 @@ class CsvConnector(BaseConnector):
             msg = f"Unsupported data type: {type(data)}"
             raise TypeError(msg)
 
-        pcsv.write_csv(tbl, filepath)
+        pcsv.write_csv(tbl, filepath)  # type: ignore[attr-defined]
         logger.info("csv written", path=str(filepath), rows=len(tbl))
 
     def health_check(self) -> bool:

--- a/src/dataenginex/data/connectors/dbt.py
+++ b/src/dataenginex/data/connectors/dbt.py
@@ -1,0 +1,158 @@
+"""dbt connector — runs a dbt model and reads back its materialized output.
+
+Uses the dbt-duckdb adapter: shells out to ``dbt run --select <model>``,
+then reads the model table from the DuckDB target database.
+
+Install dbt with::
+
+    uv sync --group dbt
+    # or: pip install dbt-core dbt-duckdb
+
+Configure a DuckDB profile in ``{project_dir}/profiles.yml`` that writes
+to ``{target_database}`` (default: ``{project_dir}/dev.duckdb``).
+
+Usage in dex.yaml::
+
+    data:
+      sources:
+        transformed_users:
+          type: dbt
+          connection:
+            project_dir: ./dbt_project
+            model: users_cleaned
+            target_database: ./dbt_project/dev.duckdb
+"""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+from pathlib import Path
+from typing import Any
+
+import duckdb
+import structlog
+
+from dataenginex.core.interfaces import BaseConnector
+from dataenginex.data.connectors import connector_registry
+from dataenginex.data.connectors._utils import rows_to_dicts
+
+logger = structlog.get_logger()
+
+_DBT_AVAILABLE = shutil.which("dbt") is not None
+
+_IMPORT_ERROR = (
+    "dbt CLI not found. Install dbt externally: "
+    "https://docs.getdbt.com/docs/core/pip-install  "
+    "For local DuckDB projects: pip install dbt-core dbt-duckdb"
+)
+
+
+@connector_registry.decorator("dbt")
+class DbtConnector(BaseConnector):
+    """dbt connector — runs a model and reads its DuckDB-materialized output.
+
+    Requires dbt-core and dbt-duckdb (install with: uv sync --group dbt).
+    DEX shells out to ``dbt run``, then queries the DuckDB target file that
+    the dbt-duckdb adapter writes to.
+
+    Args:
+        project_dir: Path to the dbt project root (must contain dbt_project.yml).
+        model: dbt model name to run and read.
+        target_database: Path to the DuckDB file dbt writes to.
+                         Defaults to ``{project_dir}/dev.duckdb``.
+        profiles_dir: Path to the dbt profiles directory.
+                      Defaults to ``project_dir``.
+        target: dbt target name (default ``"dev"``).
+    """
+
+    def __init__(
+        self,
+        project_dir: str,
+        model: str,
+        target_database: str | None = None,
+        profiles_dir: str | None = None,
+        target: str = "dev",
+        **kwargs: Any,
+    ) -> None:
+        if not _DBT_AVAILABLE:
+            raise ImportError(_IMPORT_ERROR)
+        self._project_dir = Path(project_dir)
+        self._model = model
+        self._target_db = (
+            Path(target_database) if target_database else self._project_dir / "dev.duckdb"
+        )
+        self._profiles_dir = Path(profiles_dir) if profiles_dir else self._project_dir
+        self._target = target
+
+    def connect(self) -> None:
+        project_file = self._project_dir / "dbt_project.yml"
+        if not project_file.exists():
+            msg = f"dbt project not found: {project_file}"
+            raise FileNotFoundError(msg)
+        logger.debug("dbt connector ready", project=str(self._project_dir), model=self._model)
+
+    def disconnect(self) -> None:
+        # No persistent connection — each read() opens and closes its own DuckDB handle.
+        pass
+
+    def read(
+        self,
+        *,
+        table: str | None = None,
+        default: Any = None,
+        **kwargs: Any,
+    ) -> list[dict[str, Any]]:
+        model = table or self._model
+        self._run_dbt(model)
+        return self._read_model(model, default=default)
+
+    def write(self, data: Any, *, table: str = "output", **kwargs: Any) -> None:
+        msg = "DbtConnector is read-only — writes are managed by dbt models"
+        raise NotImplementedError(msg)
+
+    def health_check(self) -> bool:
+        return (self._project_dir / "dbt_project.yml").exists()
+
+    # -------------------------------------------------------------------------
+    # Internal helpers
+    # -------------------------------------------------------------------------
+
+    def _run_dbt(self, model: str) -> None:
+        cmd = [
+            "dbt",
+            "run",
+            "--select",
+            model,
+            "--project-dir",
+            str(self._project_dir),
+            "--profiles-dir",
+            str(self._profiles_dir),
+            "--target",
+            self._target,
+        ]
+        proc = subprocess.run(cmd, capture_output=True, text=True)  # noqa: S603,S607
+        if proc.returncode != 0:
+            msg = f"dbt run failed for model '{model}':\n{proc.stdout}\n{proc.stderr}"
+            raise RuntimeError(msg)
+        logger.info("dbt run complete", model=model, target=self._target)
+
+    def _read_model(self, model: str, *, default: Any) -> list[dict[str, Any]]:
+        if not self._target_db.exists():
+            if default is not None:
+                return list(default)
+            msg = f"dbt target database not found: {self._target_db}. Run dbt first."
+            raise FileNotFoundError(msg)
+        conn = duckdb.connect(str(self._target_db), read_only=True)
+        try:
+            result = conn.execute(f"SELECT * FROM {model}")  # noqa: S608
+            rows = rows_to_dicts(result)
+        except duckdb.CatalogException:
+            if default is not None:
+                conn.close()
+                return list(default)
+            conn.close()
+            raise
+        conn.close()
+        logger.info("dbt model read", model=model, database=str(self._target_db), rows=len(rows))
+        return rows

--- a/src/dataenginex/data/connectors/duckdb.py
+++ b/src/dataenginex/data/connectors/duckdb.py
@@ -13,10 +13,9 @@ import structlog
 
 from dataenginex.core.interfaces import BaseConnector
 from dataenginex.data.connectors import connector_registry
+from dataenginex.data.connectors._utils import NOT_CONNECTED, rows_to_dicts
 
 logger = structlog.get_logger()
-
-_NOT_CONNECTED = "Not connected — call connect() first"
 
 
 @connector_registry.decorator("duckdb", is_default=True)
@@ -45,11 +44,10 @@ class DuckDBConnector(BaseConnector):
 
     def read(self, *, table: str, default: Any = None, **kwargs: Any) -> list[dict[str, Any]]:
         if self._conn is None:
-            raise RuntimeError(_NOT_CONNECTED)
+            raise RuntimeError(NOT_CONNECTED)
         try:
             result = self._conn.execute(f"SELECT * FROM {table}")  # noqa: S608
-            columns: list[str] = [desc[0] for desc in result.description]
-            return [dict(zip(columns, row, strict=True)) for row in result.fetchall()]
+            return rows_to_dicts(result)
         except duckdb.CatalogException:
             if default is not None:
                 return list(default)
@@ -57,7 +55,7 @@ class DuckDBConnector(BaseConnector):
 
     def write(self, data: Any, *, table: str, **kwargs: Any) -> None:
         if self._conn is None:
-            raise RuntimeError(_NOT_CONNECTED)
+            raise RuntimeError(NOT_CONNECTED)
         import pyarrow as pa
 
         if isinstance(data, list):
@@ -70,7 +68,15 @@ class DuckDBConnector(BaseConnector):
             msg = f"Unsupported data type: {type(data)}"
             raise TypeError(msg)
 
-        self._conn.execute(f"CREATE TABLE IF NOT EXISTS {table} AS SELECT * FROM tbl")  # noqa: S608
+        # Register to avoid frame-scan (not reliable on all connection types).
+        # CREATE OR REPLACE overwrites existing data; CREATE TABLE IF NOT EXISTS was a silent no-op.
+        self._conn.register("_dex_write_tmp", tbl)
+        try:
+            self._conn.execute(  # noqa: S608
+                f"CREATE OR REPLACE TABLE {table} AS SELECT * FROM _dex_write_tmp"
+            )
+        finally:
+            self._conn.unregister("_dex_write_tmp")
         logger.info("data written", table=table, rows=len(tbl))
 
     def health_check(self) -> bool:
@@ -85,14 +91,13 @@ class DuckDBConnector(BaseConnector):
     def execute(self, sql: str) -> list[dict[str, Any]]:
         """Execute raw SQL and return results as list of dicts."""
         if self._conn is None:
-            raise RuntimeError(_NOT_CONNECTED)
+            raise RuntimeError(NOT_CONNECTED)
         result = self._conn.execute(sql)
-        columns = [desc[0] for desc in result.description]
-        return [dict(zip(columns, row, strict=True)) for row in result.fetchall()]
+        return rows_to_dicts(result)
 
     @property
     def connection(self) -> duckdb.DuckDBPyConnection:
         """Direct access to the DuckDB connection for advanced use."""
         if self._conn is None:
-            raise RuntimeError(_NOT_CONNECTED)
+            raise RuntimeError(NOT_CONNECTED)
         return self._conn

--- a/src/dataenginex/data/connectors/legacy.py
+++ b/src/dataenginex/data/connectors/legacy.py
@@ -90,8 +90,6 @@ class DataConnector(ABC):
         self._connected_at: datetime | None = None
 
     # -- lifecycle -----------------------------------------------------------
-    # TODO(breaking): CsvConnector/DuckDBConnector implement these as sync methods,
-    # violating this async interface. Needs a coordinated fix across all subclasses.
 
     @abstractmethod
     async def connect(self) -> bool:

--- a/src/dataenginex/data/connectors/parquet.py
+++ b/src/dataenginex/data/connectors/parquet.py
@@ -1,0 +1,110 @@
+"""Parquet file connector — reads Parquet files via DuckDB.
+
+Supports single-file and directory glob patterns.  IMDB-style files with
+null markers and tab-delimited TSV.gz are handled by DuckDB natively
+through ``read_parquet``.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import duckdb
+import structlog
+
+from dataenginex.core.interfaces import BaseConnector
+from dataenginex.data.connectors import connector_registry
+
+logger = structlog.get_logger()
+
+
+@connector_registry.decorator("parquet")
+class ParquetConnector(BaseConnector):
+    """Parquet connector backed by DuckDB ``read_parquet``.
+
+    Args:
+        path: Path to a ``.parquet`` file or a directory / glob pattern.
+        default_file: Fallback filename when *path* is a directory.
+    """
+
+    def __init__(
+        self,
+        path: str = ".",
+        default_file: str | None = None,
+        **kwargs: Any,
+    ) -> None:
+        self._path = Path(path)
+        self._default_file = default_file
+        self._conn: duckdb.DuckDBPyConnection | None = None
+
+    def connect(self) -> None:
+        self._conn = duckdb.connect(":memory:")
+        logger.debug("parquet connector ready", path=str(self._path))
+
+    def disconnect(self) -> None:
+        if self._conn is not None:
+            self._conn.close()
+            self._conn = None
+
+    def _resolve_path(self, table: str | None) -> Path:
+        """Return the concrete file path to read."""
+        if self._path.is_file():
+            return self._path
+        # directory mode — look up by table/file name
+        filename = table or self._default_file
+        if filename is None:
+            msg = "No table/file specified and path is a directory"
+            raise ValueError(msg)
+        candidate = self._path / filename
+        if candidate.exists():
+            return candidate
+        with_ext = self._path / f"{filename}.parquet"
+        if with_ext.exists():
+            return with_ext
+        msg = f"Parquet file not found: {candidate} or {with_ext}"
+        raise FileNotFoundError(msg)
+
+    def read(
+        self,
+        *,
+        table: str | None = None,
+        default: Any = None,
+        **kwargs: Any,
+    ) -> list[dict[str, Any]]:
+        if self._conn is None:
+            msg = "Not connected — call connect() first"
+            raise RuntimeError(msg)
+        try:
+            filepath = self._resolve_path(table)
+        except FileNotFoundError:
+            if default is not None:
+                return list(default)
+            raise
+        safe = str(filepath).replace("'", "''")
+        result = self._conn.execute(f"SELECT * FROM read_parquet('{safe}')")
+        columns = [desc[0] for desc in result.description]
+        rows = result.fetchall()
+        logger.info("parquet read", path=safe, rows=len(rows))
+        return [dict(zip(columns, row, strict=True)) for row in rows]
+
+    def write(self, data: Any, *, table: str = "output.parquet", **kwargs: Any) -> None:
+        if self._conn is None:
+            msg = "Not connected — call connect() first"
+            raise RuntimeError(msg)
+        import pyarrow as pa
+        import pyarrow.parquet as pq
+
+        filepath = self._path / table if self._path.is_dir() else self._path
+        if isinstance(data, list):
+            tbl = pa.Table.from_pylist(data)
+        elif isinstance(data, pa.Table):
+            tbl = data
+        else:
+            msg = f"Unsupported data type: {type(data)}"
+            raise TypeError(msg)
+        pq.write_table(tbl, filepath)
+        logger.info("parquet written", path=str(filepath), rows=len(tbl))
+
+    def health_check(self) -> bool:
+        return self._conn is not None and self._path.exists()

--- a/src/dataenginex/data/connectors/parquet.py
+++ b/src/dataenginex/data/connectors/parquet.py
@@ -15,6 +15,7 @@ import structlog
 
 from dataenginex.core.interfaces import BaseConnector
 from dataenginex.data.connectors import connector_registry
+from dataenginex.data.connectors._utils import NOT_CONNECTED, rows_to_dicts
 
 logger = structlog.get_logger()
 
@@ -73,8 +74,7 @@ class ParquetConnector(BaseConnector):
         **kwargs: Any,
     ) -> list[dict[str, Any]]:
         if self._conn is None:
-            msg = "Not connected — call connect() first"
-            raise RuntimeError(msg)
+            raise RuntimeError(NOT_CONNECTED)
         try:
             filepath = self._resolve_path(table)
         except FileNotFoundError:
@@ -83,15 +83,13 @@ class ParquetConnector(BaseConnector):
             raise
         safe = str(filepath).replace("'", "''")
         result = self._conn.execute(f"SELECT * FROM read_parquet('{safe}')")
-        columns = [desc[0] for desc in result.description]
-        rows = result.fetchall()
-        logger.info("parquet read", path=safe, rows=len(rows))
-        return [dict(zip(columns, row, strict=True)) for row in rows]
+        dicts = rows_to_dicts(result)
+        logger.info("parquet read", path=safe, rows=len(dicts))
+        return dicts
 
     def write(self, data: Any, *, table: str = "output.parquet", **kwargs: Any) -> None:
         if self._conn is None:
-            msg = "Not connected — call connect() first"
-            raise RuntimeError(msg)
+            raise RuntimeError(NOT_CONNECTED)
         import pyarrow as pa
         import pyarrow.parquet as pq
 

--- a/src/dataenginex/data/connectors/parquet.py
+++ b/src/dataenginex/data/connectors/parquet.py
@@ -11,6 +11,8 @@ from pathlib import Path
 from typing import Any
 
 import duckdb
+import pyarrow as pa
+import pyarrow.parquet as pq
 import structlog
 
 from dataenginex.core.interfaces import BaseConnector
@@ -90,8 +92,6 @@ class ParquetConnector(BaseConnector):
     def write(self, data: Any, *, table: str = "output.parquet", **kwargs: Any) -> None:
         if self._conn is None:
             raise RuntimeError(NOT_CONNECTED)
-        import pyarrow as pa
-        import pyarrow.parquet as pq
 
         filepath = self._path / table if self._path.is_dir() else self._path
         if isinstance(data, list):
@@ -101,7 +101,7 @@ class ParquetConnector(BaseConnector):
         else:
             msg = f"Unsupported data type: {type(data)}"
             raise TypeError(msg)
-        pq.write_table(tbl, filepath)
+        pq.write_table(tbl, filepath)  # type: ignore[no-untyped-call]
         logger.info("parquet written", path=str(filepath), rows=len(tbl))
 
     def health_check(self) -> bool:

--- a/src/dataenginex/data/connectors/spark.py
+++ b/src/dataenginex/data/connectors/spark.py
@@ -1,0 +1,141 @@
+"""PySpark connector — reads Spark-supported sources into DEX pipelines.
+
+PySpark is optional (install with: uv sync --group data).  SparkConnector
+converts a Spark DataFrame → Arrow → list[dict] for handoff to the
+DuckDB-based pipeline runner.
+
+Usage in dex.yaml::
+
+    data:
+      sources:
+        my_lake:
+          type: spark
+          connection:
+            master: "local[*]"
+            format: parquet
+            path: "s3a://bucket/path/"
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+import structlog
+
+from dataenginex.core.interfaces import BaseConnector
+from dataenginex.data.connectors import connector_registry
+from dataenginex.data.connectors._utils import NOT_CONNECTED
+
+logger = structlog.get_logger()
+
+try:
+    import pyspark  # noqa: F401
+
+    _PYSPARK_AVAILABLE = True
+except ImportError:
+    _PYSPARK_AVAILABLE = False
+
+if TYPE_CHECKING:
+    import pyspark.sql
+
+_IMPORT_ERROR = "PySpark is required for SparkConnector. Install it with: uv sync --group data"
+
+
+@connector_registry.decorator("spark")
+class SparkConnector(BaseConnector):
+    """PySpark connector — reads any Spark-supported source into DEX.
+
+    Converts a Spark DataFrame to Arrow then to list[dict] for pipeline use.
+    PySpark is optional (install with: uv sync --group data).
+
+    Args:
+        master: Spark master URL. Use ``"local[*]"`` for local testing or
+                ``"spark://host:7077"`` for a standalone cluster.
+        app_name: Spark application name shown in the Spark UI.
+        format: Data format for the Spark reader
+                (``parquet``, ``csv``, ``json``, ``delta``, ``iceberg``).
+        path: Source path — file, directory, or glob.
+              Can also be passed per-call to ``read(table=...)``.
+        **options: Extra Spark ``DataFrameReader`` options forwarded verbatim.
+    """
+
+    def __init__(
+        self,
+        master: str = "local[*]",
+        app_name: str = "dex",
+        format: str = "parquet",
+        path: str | None = None,
+        **options: Any,
+    ) -> None:
+        if not _PYSPARK_AVAILABLE:
+            raise ImportError(_IMPORT_ERROR)
+        self._master = master
+        self._app_name = app_name
+        self._format = format
+        self._path = path
+        self._options = options
+        self._spark: pyspark.sql.SparkSession | None = None
+
+    def connect(self) -> None:
+        from pyspark.sql import SparkSession
+
+        self._spark = (
+            SparkSession.builder.master(self._master).appName(self._app_name).getOrCreate()
+        )
+        logger.debug("spark session started", master=self._master, app=self._app_name)
+
+    def disconnect(self) -> None:
+        if self._spark is not None:
+            self._spark.stop()
+            self._spark = None
+            logger.debug("spark session stopped")
+
+    def read(
+        self,
+        *,
+        table: str | None = None,
+        default: Any = None,
+        **kwargs: Any,
+    ) -> list[dict[str, Any]]:
+        if self._spark is None:
+            raise RuntimeError(NOT_CONNECTED)
+        source = table or self._path
+        if not source:
+            msg = "No path specified — set 'path' in connector config or pass 'table' to read()"
+            raise ValueError(msg)
+        try:
+            reader = self._spark.read.format(self._format)
+            if self._options:
+                reader = reader.options(**self._options)
+            df = reader.load(source)
+        except Exception:
+            if default is not None:
+                return list(default)
+            raise
+        arrow_table = df.toArrow()
+        col_names = arrow_table.schema.names
+        col_data = arrow_table.to_pydict()
+        result = [{col: col_data[col][i] for col in col_names} for i in range(arrow_table.num_rows)]
+        logger.info("spark read", path=source, format=self._format, rows=len(result))
+        return result
+
+    def write(self, data: Any, *, table: str = "output", **kwargs: Any) -> None:
+        if self._spark is None:
+            raise RuntimeError(NOT_CONNECTED)
+        if not isinstance(data, list):
+            msg = f"Unsupported data type for Spark write: {type(data)}"
+            raise TypeError(msg)
+        if not data:
+            return
+        df = self._spark.createDataFrame(data)
+        df.write.format(self._format).mode("overwrite").save(table)
+        logger.info("spark write", path=table, format=self._format, rows=len(data))
+
+    def health_check(self) -> bool:
+        if self._spark is None:
+            return False
+        try:
+            self._spark.sql("SELECT 1")
+            return True
+        except Exception:
+            return False

--- a/src/dataenginex/data/pipeline/runner.py
+++ b/src/dataenginex/data/pipeline/runner.py
@@ -1,10 +1,17 @@
 """PipelineRunner — config-driven data pipeline execution.
 
-Flow: Config -> Extract (connector) -> Transform chain -> Quality gate -> Load (lakehouse layer)
+Flow: Config -> Extract (connector or lakehouse) -> Register views ->
+      Transform chain -> Quality gate -> Load (correct lakehouse layer)
+
+Layer resolution (explicit beats implicit):
+  - If cfg.target["layer"] is set, use that.
+  - Otherwise infer from pipeline name prefix:
+      bronze_* → bronze   gold_* → gold   everything else → silver
 """
 
 from __future__ import annotations
 
+import contextlib
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
@@ -24,6 +31,7 @@ from dataenginex.data.connectors import connector_registry
 # Import to trigger registration
 from dataenginex.data.connectors.csv import CsvConnector as _CsvConnector  # noqa: F401
 from dataenginex.data.connectors.duckdb import DuckDBConnector as _DuckDBConnector  # noqa: F401
+from dataenginex.data.connectors.parquet import ParquetConnector as _ParquetConnector  # noqa: F401
 from dataenginex.data.pipeline.dag import resolve_execution_order
 from dataenginex.data.quality.gates import check_quality
 from dataenginex.data.transforms import transform_registry
@@ -36,6 +44,20 @@ from dataenginex.middleware.domain_metrics import quality_gate_evaluations_total
 from dataenginex.warehouse.lineage import LineageBackend
 
 logger = structlog.get_logger()
+
+# Prefixes that imply a specific lakehouse layer when no explicit target is set.
+_LAYER_PREFIXES: list[tuple[str, str]] = [
+    ("bronze_", "bronze"),
+    ("gold_", "gold"),
+]
+
+
+def _infer_layer(pipeline_name: str) -> str:
+    """Return the lakehouse layer implied by a pipeline name prefix."""
+    for prefix, layer in _LAYER_PREFIXES:
+        if pipeline_name.startswith(prefix):
+            return layer
+    return "silver"
 
 
 @dataclass
@@ -68,6 +90,8 @@ class PipelineRunner:
     Args:
         config: Loaded DexConfig.
         data_dir: Root directory for lakehouse layer storage.
+        project_dir: Project root — used to resolve relative source paths.
+        lineage: Optional lineage backend.
     """
 
     def __init__(
@@ -82,6 +106,10 @@ class PipelineRunner:
         self._data_dir.mkdir(parents=True, exist_ok=True)
         self._project_dir = project_dir
         self._lineage = lineage
+
+    # -------------------------------------------------------------------------
+    # Public API
+    # -------------------------------------------------------------------------
 
     def run(self, pipeline_name: str, *, dry_run: bool = False) -> PipelineResult:
         """Run a single pipeline by name."""
@@ -112,6 +140,30 @@ class PipelineRunner:
         finally:
             conn.close()
 
+    def run_all(self) -> dict[str, PipelineResult]:
+        """Run all pipelines in dependency order."""
+        if not self._config.data.pipelines:
+            return {}
+
+        dep_graph: dict[str, list[str]] = {
+            name: list(p.depends_on) for name, p in self._config.data.pipelines.items()
+        }
+        order = resolve_execution_order(dep_graph)
+        results: dict[str, PipelineResult] = {}
+
+        for name in order:
+            result = self.run(name)
+            results[name] = result
+            if not result.success:
+                logger.error("pipeline failed — stopping", pipeline=name)
+                break
+
+        return results
+
+    # -------------------------------------------------------------------------
+    # Internal pipeline steps
+    # -------------------------------------------------------------------------
+
     def _execute(
         self,
         conn: duckdb.DuckDBPyConnection,
@@ -119,7 +171,12 @@ class PipelineRunner:
         cfg: PipelineConfig,
         log: Any,
     ) -> PipelineResult:
-        """Core pipeline execution: extract -> transform -> quality -> load."""
+        """Core pipeline execution: extract -> register views -> transform -> quality -> load."""
+        # Register all existing lakehouse parquet files as DuckDB views so that
+        # cross-pipeline SQL references (e.g. silver_movies JOIN bronze_ratings)
+        # resolve correctly inside the same connection.
+        self._register_lakehouse_views(conn, log)
+
         rows_input = self._extract(conn, name, cfg, log)
         current_table, steps = self._transform(conn, name, cfg, log)
         self._check_quality(conn, name, cfg, current_table, log)
@@ -133,6 +190,30 @@ class PipelineRunner:
             steps_completed=steps,
         )
 
+    def _register_lakehouse_views(
+        self,
+        conn: duckdb.DuckDBPyConnection,
+        log: Any,
+    ) -> None:
+        """Register every parquet file in the lakehouse as a DuckDB view.
+
+        This makes previously-run pipeline outputs visible to SQL transforms
+        without requiring the runner to manage a shared DuckDB file.  Views
+        are overwritten on each pipeline run so stale data is never referenced.
+        """
+        for layer in ("bronze", "silver", "gold"):
+            layer_dir = self._data_dir / layer
+            if not layer_dir.exists():
+                continue
+            for pf in sorted(layer_dir.glob("*.parquet")):
+                safe = str(pf).replace("'", "''")
+                with contextlib.suppress(Exception):
+                    conn.execute(
+                        f"CREATE OR REPLACE VIEW {pf.stem} AS"
+                        f" SELECT * FROM read_parquet('{safe}')"
+                    )
+        log.debug("lakehouse views registered")
+
     def _extract(
         self,
         conn: duckdb.DuckDBPyConnection,
@@ -140,12 +221,37 @@ class PipelineRunner:
         cfg: PipelineConfig,
         log: Any,
     ) -> int:
-        """Extract source data into DuckDB bronze table. Returns row count."""
-        sources = self._config.data.sources
-        if cfg.source not in sources:
-            msg = f"Source '{cfg.source}' not found"
-            raise PipelineStepError(step="extract", cause=msg, pipeline=name)
+        """Extract source data into a ``bronze`` table in *conn*.
 
+        Source resolution order:
+        1. Named entry in ``data.sources`` (standard path).
+        2. Pipeline name in ``data.pipelines`` → load from its lakehouse output.
+        3. Fail with a descriptive PipelineStepError.
+        """
+        sources = self._config.data.sources
+        pipelines = self._config.data.pipelines
+
+        if cfg.source in sources:
+            return self._extract_from_source(conn, name, cfg, log)
+
+        if cfg.source in pipelines:
+            return self._extract_from_lakehouse(conn, name, cfg, log)
+
+        msg = (
+            f"Source '{cfg.source}' not found in data.sources or data.pipelines. "
+            f"Available sources: {list(sources.keys())}"
+        )
+        raise PipelineStepError(step="extract", cause=msg, pipeline=name)
+
+    def _extract_from_source(
+        self,
+        conn: duckdb.DuckDBPyConnection,
+        name: str,
+        cfg: PipelineConfig,
+        log: Any,
+    ) -> int:
+        """Standard connector-based extraction."""
+        sources = self._config.data.sources
         source_config = sources[cfg.source]
         connector_cls = connector_registry.get(source_config.type)
 
@@ -166,7 +272,8 @@ class PipelineRunner:
 
         bronze_arrow = pa.Table.from_pylist(raw_data)  # noqa: F841 — referenced by DuckDB SQL
         conn.execute("CREATE OR REPLACE TABLE bronze AS SELECT * FROM bronze_arrow")
-        log.info("extract complete", source=cfg.source, rows=len(raw_data))
+        log.info("extract complete (source)", source=cfg.source, rows=len(raw_data))
+
         if self._lineage is not None:
             self._lineage.record(
                 operation="ingest",
@@ -179,6 +286,66 @@ class PipelineRunner:
                 step_name="extract",
             )
         return len(raw_data)
+
+    def _extract_from_lakehouse(
+        self,
+        conn: duckdb.DuckDBPyConnection,
+        name: str,
+        cfg: PipelineConfig,
+        log: Any,
+    ) -> int:
+        """Load a previously-run pipeline's output as the bronze table.
+
+        Searches bronze → silver → gold layers in order.
+        """
+        source_name = cfg.source
+        # Search in most-likely layer first (inferred from source name prefix).
+        candidate_layers = [_infer_layer(source_name), "bronze", "silver", "gold"]
+        # Deduplicate while preserving order.
+        seen: set[str] = set()
+        layers: list[str] = []
+        for lyr in candidate_layers:
+            if lyr not in seen:
+                layers.append(lyr)
+                seen.add(lyr)
+
+        parquet_path: Path | None = None
+        for layer in layers:
+            candidate = self._data_dir / layer / f"{source_name}.parquet"
+            if candidate.exists():
+                parquet_path = candidate
+                break
+
+        if parquet_path is None:
+            msg = (
+                f"Lakehouse output for pipeline '{source_name}' not found. "
+                "Run upstream pipelines first."
+            )
+            raise PipelineStepError(step="extract", cause=msg, pipeline=name)
+
+        safe = str(parquet_path).replace("'", "''")
+        conn.execute(f"CREATE OR REPLACE TABLE bronze AS SELECT * FROM read_parquet('{safe}')")
+        row = conn.execute("SELECT COUNT(*) FROM bronze").fetchone()
+        rows = int(row[0]) if row else 0
+        log.info(
+            "extract complete (lakehouse)",
+            source=source_name,
+            path=str(parquet_path),
+            rows=rows,
+        )
+
+        if self._lineage is not None:
+            self._lineage.record(
+                operation="ingest",
+                layer=_infer_layer(name),
+                source=str(parquet_path),
+                destination=f"{_infer_layer(name)}/{name}",
+                input_count=rows,
+                output_count=rows,
+                pipeline_name=name,
+                step_name="extract",
+            )
+        return rows
 
     def _transform(
         self,
@@ -219,7 +386,7 @@ class PipelineRunner:
         if not cfg.quality:
             return
         q = cfg.quality
-        # Resolve _data placeholder to the actual current table, same as SQLTransform does
+        # Resolve _data placeholder to the actual current table.
         resolved_sql = q.custom_sql.replace("_data", table) if q.custom_sql else None
         result = check_quality(
             conn,
@@ -254,18 +421,27 @@ class PipelineRunner:
         table: str,
         log: Any,
     ) -> int:
-        """Write final table to lakehouse layer as parquet. Returns row count."""
+        """Write the final table to the correct lakehouse layer as Parquet.
+
+        Layer resolution (explicit > inferred):
+        - cfg.target["layer"] if present.
+        - Otherwise _infer_layer(pipeline_name) from name prefix.
+        """
         count_row = conn.execute(f"SELECT count(*) FROM {table}").fetchone()
         rows = int(count_row[0]) if count_row else 0
-        target_layer = "silver"
+
         if cfg.target:
-            target_layer = cfg.target.get("layer", "silver")
+            target_layer = cfg.target.get("layer", _infer_layer(name))
+        else:
+            target_layer = _infer_layer(name)
 
         layer_dir = self._data_dir / target_layer
         layer_dir.mkdir(parents=True, exist_ok=True)
-        output_path = layer_dir / f"{name}.parquet"
+        output_name = cfg.destination or name
+        output_path = layer_dir / f"{output_name}.parquet"
         conn.execute(f"COPY {table} TO '{output_path}' (FORMAT PARQUET)")
         log.info("load complete", layer=target_layer, path=str(output_path), rows=rows)
+
         if self._lineage is not None:
             self._lineage.record(
                 operation="load",
@@ -278,23 +454,3 @@ class PipelineRunner:
                 step_name="load",
             )
         return rows
-
-    def run_all(self) -> dict[str, PipelineResult]:
-        """Run all pipelines in dependency order."""
-        if not self._config.data.pipelines:
-            return {}
-
-        dep_graph: dict[str, list[str]] = {
-            name: list(p.depends_on) for name, p in self._config.data.pipelines.items()
-        }
-        order = resolve_execution_order(dep_graph)
-        results: dict[str, PipelineResult] = {}
-
-        for name in order:
-            result = self.run(name)
-            results[name] = result
-            if not result.success:
-                logger.error("pipeline failed — stopping", pipeline=name)
-                break
-
-        return results

--- a/src/dataenginex/data/pipeline/runner.py
+++ b/src/dataenginex/data/pipeline/runner.py
@@ -30,8 +30,10 @@ from dataenginex.data.connectors import connector_registry
 
 # Import to trigger registration
 from dataenginex.data.connectors.csv import CsvConnector as _CsvConnector  # noqa: F401
+from dataenginex.data.connectors.dbt import DbtConnector as _DbtConnector  # noqa: F401
 from dataenginex.data.connectors.duckdb import DuckDBConnector as _DuckDBConnector  # noqa: F401
 from dataenginex.data.connectors.parquet import ParquetConnector as _ParquetConnector  # noqa: F401
+from dataenginex.data.connectors.spark import SparkConnector as _SparkConnector  # noqa: F401
 from dataenginex.data.pipeline.dag import resolve_execution_order
 from dataenginex.data.quality.gates import check_quality
 from dataenginex.data.transforms import transform_registry
@@ -279,8 +281,8 @@ class PipelineRunner:
         raw_data = connector.read(table=read_table)
         connector.disconnect()
 
-        bronze_arrow = pa.Table.from_pylist(raw_data)  # noqa: F841 — referenced by DuckDB SQL
-        conn.execute("CREATE OR REPLACE TABLE bronze AS SELECT * FROM bronze_arrow")
+        conn.register("_raw_src", pa.Table.from_pylist(raw_data))
+        conn.execute("CREATE OR REPLACE TABLE bronze AS SELECT * FROM _raw_src")
         log.info("extract complete (source)", source=cfg.source, rows=len(raw_data))
 
         if self._lineage is not None:

--- a/src/dataenginex/data/pipeline/runner.py
+++ b/src/dataenginex/data/pipeline/runner.py
@@ -92,6 +92,9 @@ class PipelineRunner:
         data_dir: Root directory for lakehouse layer storage.
         project_dir: Project root — used to resolve relative source paths.
         lineage: Optional lineage backend.
+        feature_store: Optional feature store — gold tables are saved as feature groups.
+        vector_store: Optional vector store — gold/silver rows are embedded on completion.
+        embed_fn: Embedding callable for vector store ingest.
     """
 
     def __init__(
@@ -100,12 +103,18 @@ class PipelineRunner:
         data_dir: Path | None = None,
         project_dir: Path | None = None,
         lineage: LineageBackend | None = None,
+        feature_store: Any = None,
+        vector_store: Any = None,
+        embed_fn: Any = None,
     ) -> None:
         self._config = config
         self._data_dir = data_dir or Path(".dex/lakehouse")
         self._data_dir.mkdir(parents=True, exist_ok=True)
         self._project_dir = project_dir
         self._lineage = lineage
+        self._feature_store = feature_store
+        self._vector_store = vector_store
+        self._embed_fn = embed_fn
 
     # -------------------------------------------------------------------------
     # Public API
@@ -181,6 +190,7 @@ class PipelineRunner:
         current_table, steps = self._transform(conn, name, cfg, log)
         self._check_quality(conn, name, cfg, current_table, log)
         rows_output = self._load(conn, name, cfg, current_table, log)
+        self._post_load_hooks(conn, name, cfg, current_table, log)
 
         return PipelineResult(
             pipeline=name,
@@ -209,8 +219,7 @@ class PipelineRunner:
                 safe = str(pf).replace("'", "''")
                 with contextlib.suppress(Exception):
                     conn.execute(
-                        f"CREATE OR REPLACE VIEW {pf.stem} AS"
-                        f" SELECT * FROM read_parquet('{safe}')"
+                        f"CREATE OR REPLACE VIEW {pf.stem} AS SELECT * FROM read_parquet('{safe}')"
                     )
         log.debug("lakehouse views registered")
 
@@ -454,3 +463,70 @@ class PipelineRunner:
                 step_name="load",
             )
         return rows
+
+    def _post_load_hooks(
+        self,
+        conn: duckdb.DuckDBPyConnection,
+        name: str,
+        cfg: PipelineConfig,
+        table: str,
+        log: Any,
+    ) -> None:
+        """Run optional post-load integrations: feature store save + vector ingest."""
+        target_layer = (
+            (cfg.target or {}).get("layer", _infer_layer(name))
+            if cfg.target
+            else _infer_layer(name)
+        )
+
+        # ── Feature store ──────────────────────────────────────────────────────
+        if self._feature_store is not None and target_layer == "gold":
+            with contextlib.suppress(Exception):
+                rows_data = conn.execute(f"SELECT * FROM {table} LIMIT 50000").fetchall()  # noqa: S608
+                desc = conn.execute(f"DESCRIBE {table}").fetchall()
+                cols = [d[0] for d in desc]
+                records = [dict(zip(cols, r, strict=True)) for r in rows_data]
+                _entity_keys = {"movie_id", "tconst", "nconst", "director_id", "person_id"}
+                entity_key = next(
+                    (c for c in cols if c in _entity_keys),
+                    cols[0],
+                )
+                self._feature_store.save_features(
+                    feature_group=name,
+                    data=records,
+                    entity_key=entity_key,
+                )
+                log.info("feature store updated", feature_group=name, rows=len(records))
+
+        # ── Vector store ingest ────────────────────────────────────────────────
+        if self._vector_store is not None and target_layer in ("silver", "gold"):
+            with contextlib.suppress(Exception):
+                from dataenginex.ai.vectorstore import Document, RAGPipeline
+
+                rows_data = conn.execute(f"SELECT * FROM {table} LIMIT 5000").fetchall()  # noqa: S608
+                desc = conn.execute(f"DESCRIBE {table}").fetchall()
+                cols = [d[0] for d in desc]
+                skip = {"movie_id", "tconst", "nconst", "director_id", "person_id", "series_id"}
+                text_cols = {"title", "director_name", "genre", "person_name", "original_title"}
+                docs: list[Document] = []
+                for row in rows_data:
+                    record = dict(zip(cols, row, strict=True))
+                    text = " | ".join(
+                        f"{k}: {v}" for k, v in record.items() if v is not None and k not in skip
+                    )[:512]
+                    meta = {
+                        "table": name,
+                        "layer": target_layer,
+                        **{
+                            k: str(v) for k, v in record.items() if k in text_cols and v is not None
+                        },
+                    }
+                    docs.append(Document(text=text, metadata=meta))
+
+                rag = RAGPipeline(
+                    store=self._vector_store,
+                    embed_fn=self._embed_fn,
+                    dimension=384,
+                )
+                rag.store.upsert(docs)
+                log.info("vector store updated", table=name, documents=len(docs))

--- a/src/dataenginex/engine.py
+++ b/src/dataenginex/engine.py
@@ -58,6 +58,8 @@ class DexBackend(Protocol):
     ai_memory: Any
     ai_episodic: Any
     ai_audit: Any
+    secops_audit: Any
+    privacy_guard: Any
     plugins: Any
     catalog: Any
     project_dir: Any
@@ -176,6 +178,8 @@ class DexEngine:
         self.checkpoint_mgr: Any = None
         self.sandbox: Any = None
         self.model_router: Any = None
+        # SecOps AuditLogger (secops.audit config) — separate from ai_audit
+        self.secops_audit: Any = None
         # PrivacyGuard must initialise even if the AI layer fails — it's a
         # security primitive consumed independently (e.g. by dex-studio's
         # /privacy/* UI). Initialise before _init_ai_layer so the guard is
@@ -779,9 +783,14 @@ class DexEngine:
     def _init_privacy_guard(self) -> None:
         """Build a ``PrivacyGuard`` from ``dex.yaml secops.guard``.
 
+        Also constructs a :class:`~dataenginex.secops.AuditLogger` when
+        ``secops.audit.enabled`` is ``True``, stored on ``self.secops_audit``.
+        An empty ``db_path`` uses in-memory DuckDB; a relative path is
+        resolved under ``<project>/.dex/``; absolute paths are used as-is.
+
         Stored on ``self.privacy_guard``. Used by ``_init_model_router`` to
         wrap every LLM provider, and exposed for downstream consumers
-        (dex-studio's ``/privacy/*`` UI, custom integrations).
+        (dex-studio's ``/secops/*`` UI, custom integrations).
         """
         from dataenginex.secops import (
             AuditLogger,
@@ -792,9 +801,22 @@ class DexEngine:
         guard_dict = self.config.secops.guard.model_dump()
         guard_cfg = PrivacyGuardConfig.from_dict(guard_dict)
 
-        audit_logger = getattr(self, "audit", None)
-        if not isinstance(audit_logger, AuditLogger):
-            audit_logger = None
+        audit_logger: AuditLogger | None = None
+        if self.config.secops.audit.enabled:
+            raw_path = self.config.secops.audit.db_path.strip()
+            if not raw_path:
+                db_path = ":memory:"
+            else:
+                from pathlib import Path as _Path
+
+                p = _Path(raw_path)
+                db_path = str(p if p.is_absolute() else self._dex_dir / p)
+            audit_logger = AuditLogger(db_path=db_path)
+            self.secops_audit = audit_logger
+            logger.info(
+                "secops_audit.initialized",
+                db_path=db_path,
+            )
 
         self.privacy_guard = PrivacyGuard(
             config=guard_cfg,

--- a/src/dataenginex/engine.py
+++ b/src/dataenginex/engine.py
@@ -176,6 +176,11 @@ class DexEngine:
         self.checkpoint_mgr: Any = None
         self.sandbox: Any = None
         self.model_router: Any = None
+        # PrivacyGuard must initialise even if the AI layer fails — it's a
+        # security primitive consumed independently (e.g. by dex-studio's
+        # /privacy/* UI). Initialise before _init_ai_layer so the guard is
+        # always available, then wire it into the router inside the AI init.
+        self._init_privacy_guard()
         self._init_ai_layer()
 
         # Plugin discovery
@@ -771,24 +776,54 @@ class DexEngine:
         except Exception:
             logger.warning("AI layer init failed")
 
+    def _init_privacy_guard(self) -> None:
+        """Build a ``PrivacyGuard`` from ``dex.yaml secops.guard``.
+
+        Stored on ``self.privacy_guard``. Used by ``_init_model_router`` to
+        wrap every LLM provider, and exposed for downstream consumers
+        (dex-studio's ``/privacy/*`` UI, custom integrations).
+        """
+        from dataenginex.secops import (
+            AuditLogger,
+            PrivacyGuard,
+            PrivacyGuardConfig,
+        )
+
+        guard_dict = self.config.secops.guard.model_dump()
+        guard_cfg = PrivacyGuardConfig.from_dict(guard_dict)
+
+        audit_logger = getattr(self, "audit", None)
+        if not isinstance(audit_logger, AuditLogger):
+            audit_logger = None
+
+        self.privacy_guard = PrivacyGuard(
+            config=guard_cfg,
+            audit_logger=audit_logger,
+        )
+
     def _init_model_router(self) -> None:
         import os
 
-        from dataenginex.ai.routing.router import ModelRouter
+        from dataenginex.ai.routing.guarded import GuardedProvider
+        from dataenginex.ai.routing.router import BaseProvider, ModelRouter
 
-        providers: dict[str, Any] = {}
+        def _wrap(name: str, provider: BaseProvider) -> BaseProvider:
+            """Wrap *provider* with the guard. Local targets bypass at call time."""
+            return GuardedProvider(provider, self.privacy_guard, target=name)
+
+        providers: dict[str, BaseProvider] = {}
         if os.environ.get("ANTHROPIC_API_KEY"):
             from dataenginex.ai.routing.anthropic import AnthropicProvider
 
-            providers["anthropic"] = AnthropicProvider()
+            providers["anthropic"] = _wrap("anthropic", AnthropicProvider())
         if os.environ.get("OPENAI_API_KEY"):
             from dataenginex.ai.routing.openai import OpenAIProvider
 
-            providers["openai"] = OpenAIProvider()
+            providers["openai"] = _wrap("openai", OpenAIProvider())
 
         from dataenginex.ai.routing.ollama import OllamaProvider
 
-        providers.setdefault("ollama", OllamaProvider())
+        providers.setdefault("ollama", _wrap("ollama", OllamaProvider()))
 
         if providers:
             self.model_router = ModelRouter(providers)

--- a/src/dataenginex/engine.py
+++ b/src/dataenginex/engine.py
@@ -98,7 +98,14 @@ class DexBackend(Protocol):
 
     def add_pipeline(self, name: str, source: str, schedule: str, destination: str) -> None: ...
     def delete_pipeline(self, name: str) -> None: ...
-    def add_source(self, name: str, type_: str, path: str = "", url: str = "") -> None: ...
+    def add_source(
+        self,
+        name: str,
+        type_: str,
+        path: str = "",
+        url: str = "",
+        connection: dict[str, Any] | None = None,
+    ) -> None: ...
     def delete_source(self, name: str) -> None: ...
     def add_agent(self, name: str, runtime: str, system_prompt: str) -> None: ...
     def delete_agent(self, name: str) -> None: ...
@@ -324,11 +331,21 @@ class DexEngine:
         self.config.data.pipelines.pop(name, None)
         self._save_config()
 
-    def add_source(self, name: str, type_: str, path: str = "", url: str = "") -> None:
+    def add_source(
+        self,
+        name: str,
+        type_: str,
+        path: str = "",
+        url: str = "",
+        connection: dict[str, Any] | None = None,
+    ) -> None:
         from dataenginex.config.schema import SourceConfig
 
         self.config.data.sources[name] = SourceConfig(
-            type=type_, path=path or None, url=url or None
+            type=type_,
+            path=path or None,
+            url=url or None,
+            connection=connection or {},
         )
         self._save_config()
 
@@ -539,7 +556,7 @@ class DexEngine:
         with contextlib.suppress(Exception), duckdb.connect(":memory:") as conn:
             rows = conn.execute(f"DESCRIBE SELECT * FROM {read_fn}('{qpath}') LIMIT 1").fetchall()
             return [
-                {"column_name": r[0], "column_type": r[1], "nullable": r[3] == "YES"} for r in rows
+                {"column_name": r[0], "column_type": r[1], "nullable": r[3] != "NO"} for r in rows
             ]
         return None
 

--- a/src/dataenginex/engine.py
+++ b/src/dataenginex/engine.py
@@ -56,6 +56,7 @@ class DexBackend(Protocol):
     serving_engine: Any
     llm: Any
     ai_memory: Any
+    ai_metrics: Any
     ai_episodic: Any
     ai_audit: Any
     secops_audit: Any
@@ -149,22 +150,30 @@ class DexEngine:
         # Lakehouse catalog — tracks every dataset written to .dex/lakehouse/
         self.catalog = DataCatalog(persist_path=self._dex_dir / "catalog.json")
 
-        # Data pipeline runner — passes store as lineage backend
+        # ML backends — init before pipeline runner so feature_store is available
+        self.tracker: Any = self._init_ml_tracker()
+        self.feature_store: Any = self._init_ml_feature_store()
+        self.serving_engine: Any = self._init_ml_serving()
+
+        # Vector store — init before pipeline runner and AI so both can share it
+        self._vector_store: Any = None
+        self._embed_fn: Any = None
+        self._vector_store, self._embed_fn = self._init_vector_store()
+
+        # Data pipeline runner — has access to feature store + vector store
         from dataenginex.data.pipeline.runner import PipelineRunner
 
         self.pipeline_runner = PipelineRunner(
             self.config,
             data_dir=self._dex_dir / "lakehouse",
             project_dir=self.project_dir,
-            lineage=self.store,  # DexStore.record() satisfies PersistentLineage interface
+            lineage=self.store,
+            feature_store=self.feature_store,
+            vector_store=self._vector_store,
+            embed_fn=self._embed_fn,
         )
 
-        # ML backends
-        self.tracker: Any = self._init_ml_tracker()
-        self.feature_store: Any = self._init_ml_feature_store()
-        self.serving_engine: Any = self._init_ml_serving()
-
-        # AI backends
+        # AI backends — ingest existing lakehouse into vector store, init agents
         self.llm: Any = None
         self.agents: dict[str, Any] = {}
         self._init_ai()
@@ -373,7 +382,7 @@ class DexEngine:
                 )
                 updated_at = datetime.datetime.fromtimestamp(stat.st_mtime).strftime("%b %d %H:%M")
                 row_count: int | None = None
-                with contextlib.suppress(Exception), self._duckdb() as conn:
+                with contextlib.suppress(Exception), self._duckdb_ro() as conn:
                     row = conn.execute(f"SELECT COUNT(*) FROM read_parquet('{f}')").fetchone()
                     row_count = int(row[0]) if row else None
 
@@ -406,7 +415,7 @@ class DexEngine:
         if not table_path.exists():
             return []
         try:
-            with self._duckdb() as conn:
+            with self._duckdb_ro() as conn:
                 conn.execute(f"CREATE VIEW IF NOT EXISTS _wts AS SELECT * FROM '{table_path}'")
                 cols = conn.execute("DESCRIBE _wts").fetchall()
                 conn.execute("DROP VIEW IF EXISTS _wts")
@@ -422,7 +431,7 @@ class DexEngine:
         size = table_path.stat().st_size
         schema = self.warehouse_table_schema(table_name, layer)
         row_count = None
-        with contextlib.suppress(Exception), self._duckdb() as conn:
+        with contextlib.suppress(Exception), self._duckdb_ro() as conn:
             row_count = conn.execute(
                 f"SELECT COUNT(*) FROM read_parquet('{table_path}')"
             ).fetchone()[0]
@@ -586,7 +595,7 @@ class DexEngine:
         if not table_path.exists():
             return None
         try:
-            with self._duckdb() as conn:
+            with self._duckdb_ro() as conn:
                 conn.execute(f"CREATE VIEW IF NOT EXISTS _qc AS SELECT * FROM '{table_path}'")
                 col_result = conn.execute("DESCRIBE _qc").fetchall()
                 column_names = [r[0] for r in col_result]
@@ -671,13 +680,64 @@ class DexEngine:
 
     @contextlib.contextmanager
     def _duckdb(self) -> Iterator[Any]:
-        """Yield the DexStore's DuckDB connection for ad-hoc queries."""
+        """Yield the DexStore's DuckDB connection for store-level writes only.
+
+        Never use this for read-only parquet queries — those must open their own
+        in-memory connection via _duckdb_ro() to avoid cross-thread contention.
+        """
         yield self.store.connection
 
+    @contextlib.contextmanager
+    def _duckdb_ro(self) -> Iterator[Any]:
+        """Yield a fresh in-memory DuckDB connection for read-only parquet queries.
+
+        Keeps read traffic off the shared store connection so pipeline runs
+        executing in a thread-pool executor don't race with web-request reads.
+        """
+        conn = duckdb.connect(":memory:")
+        try:
+            yield conn
+        finally:
+            with contextlib.suppress(Exception):
+                conn.close()
+
     def _save_config(self) -> None:
-        dump = self.config.model_dump()
-        with open(self.config_path, "w") as f:
-            yaml.dump(dump, f, default_flow_style=False, sort_keys=False)
+        """Write config atomically: temp file → os.replace.
+
+        Strips None/empty values so the file stays readable. Writes a .bak
+        alongside the config before every save so the user can recover.
+        """
+        import os
+
+        dump = self._config_dump_clean()
+        tmp = self.config_path.with_suffix(".yaml.tmp")
+        bak = self.config_path.with_suffix(".yaml.bak")
+        try:
+            with tmp.open("w") as f:
+                yaml.dump(dump, f, default_flow_style=False, sort_keys=False, allow_unicode=True)
+            # Backup current config before overwriting
+            if self.config_path.exists():
+                import shutil
+
+                shutil.copy2(self.config_path, bak)
+            os.replace(tmp, self.config_path)  # atomic on POSIX and Windows
+        except Exception:
+            tmp.unlink(missing_ok=True)
+            raise
+
+    def _config_dump_clean(self) -> dict[str, Any]:
+        """Return config as dict with None/empty-dict values removed recursively."""
+        from typing import cast as _cast
+
+        def _strip(obj: Any) -> Any:
+            if isinstance(obj, dict):
+                cleaned = {k: _strip(v) for k, v in obj.items() if v is not None}
+                return {k: v for k, v in cleaned.items() if v != {} and v != []}
+            if isinstance(obj, list):
+                return [_strip(i) for i in obj]
+            return obj
+
+        return _cast(dict[str, Any], _strip(self.config.model_dump()))
 
     def _init_ml_tracker(self) -> Any:
         try:
@@ -721,6 +781,79 @@ class DexEngine:
             logger.warning("serving engine init failed")
             return None
 
+    def _init_vector_store(self) -> tuple[Any, Any]:
+        """Initialise in-memory vector store + embedding function.
+
+        Returns (vector_store, embed_fn). Both may be None on failure.
+        Falls back to hash-based embedding when sentence-transformers is absent.
+        """
+        vector_store: Any = None
+        embed_fn: Any = None
+        try:
+            from dataenginex.ai.vectorstore import InMemoryBackend
+
+            vector_store = InMemoryBackend(dimension=384)
+            with contextlib.suppress(ImportError):
+                from dataenginex.ai.vectorstore import SentenceTransformerEmbedder
+
+                embed_fn = SentenceTransformerEmbedder()
+                logger.info("sentence transformer embedder ready")
+            logger.info("vector store initialised", backend="in-memory")
+        except Exception:
+            logger.warning("vector store init failed")
+        return vector_store, embed_fn
+
+    def _ingest_lakehouse_to_vector_store(self) -> None:
+        """Embed and index gold/silver tables into the vector store on startup."""
+        if self._vector_store is None:
+            return
+        lakehouse = self._dex_dir / "lakehouse"
+        try:
+            from dataenginex.ai.vectorstore import Document, RAGPipeline
+
+            rag = RAGPipeline(
+                store=self._vector_store,
+                embed_fn=self._embed_fn,
+                dimension=384,
+            )
+            ingested = 0
+            for layer in ("silver", "gold"):
+                layer_dir = lakehouse / layer
+                if not layer_dir.exists():
+                    continue
+                for pf in sorted(layer_dir.glob("*.parquet")):
+                    with contextlib.suppress(Exception):
+                        import duckdb
+
+                        conn = duckdb.connect(":memory:")
+                        safe = str(pf).replace("'", "''")
+                        rows = conn.execute(
+                            f"SELECT * FROM read_parquet('{safe}') LIMIT 5000"
+                        ).fetchall()
+                        desc = conn.execute(
+                            f"DESCRIBE SELECT * FROM read_parquet('{safe}')"
+                        ).fetchall()
+                        conn.close()
+                        cols = [d[0] for d in desc]
+                        docs: list[Document] = []
+                        for row in rows:
+                            record = dict(zip(cols, row, strict=True))
+                            text = " | ".join(
+                                f"{k}: {v}" for k, v in record.items() if v is not None
+                            )[:512]
+                            docs.append(
+                                Document(
+                                    text=text,
+                                    metadata={"table": pf.stem, "layer": layer},
+                                )
+                            )
+                        if docs:
+                            rag.store.upsert(docs)
+                            ingested += len(docs)
+            logger.info("vector store populated", documents=ingested)
+        except Exception as exc:
+            logger.warning("vector store ingest failed", error=str(exc))
+
     def _init_ai(self) -> None:
         try:
             from dataenginex.ai.llm import get_llm_provider
@@ -729,6 +862,20 @@ class DexEngine:
         except Exception:
             self.llm = None
             logger.warning("LLM provider unavailable")
+
+        # Register tools regardless of LLM availability — predict/search_similar are LLM-free.
+        try:
+            from dataenginex.ai.tools.builtin import register_builtin_tools
+
+            self._ingest_lakehouse_to_vector_store()
+            register_builtin_tools(
+                lakehouse_dir=self._dex_dir / "lakehouse",
+                models_dir=self._dex_dir / "models",
+                vector_store=self._vector_store,
+                embed_fn=self._embed_fn,
+            )
+        except Exception:
+            logger.warning("tool registration failed")
 
         if self.llm is None:
             return
@@ -739,9 +886,7 @@ class DexEngine:
             import dataenginex.ai.agents.builtin  # noqa: F401
             from dataenginex.ai.agents import agent_registry
             from dataenginex.ai.tools import tool_registry
-            from dataenginex.ai.tools.builtin import register_builtin_tools
 
-            register_builtin_tools()
             for name, agent_cfg in self.config.ai.agents.items():
                 agent_llm = self.llm
                 if agent_cfg.model:
@@ -755,6 +900,7 @@ class DexEngine:
                     system_prompt=agent_cfg.system_prompt,
                     tools=tool_registry,
                     max_iterations=agent_cfg.max_iterations,
+                    name=name,
                 )
                 logger.info("agent initialized", agent=name)
         except Exception:

--- a/src/dataenginex/lakehouse/storage.py
+++ b/src/dataenginex/lakehouse/storage.py
@@ -36,8 +36,8 @@ __all__ = [
 
 # Try importing pyarrow — optional heavyweight dependency
 try:
-    import pyarrow as pa  # type: ignore[import-not-found]
-    import pyarrow.parquet as pq  # type: ignore[import-not-found]
+    import pyarrow as pa  # type: ignore[import-not-found,import-untyped]
+    import pyarrow.parquet as pq  # type: ignore[import-not-found,import-untyped,no-untyped-call]
 
     _HAS_PYARROW = True
 except ImportError:
@@ -166,7 +166,7 @@ class ParquetStorage(StorageBackend):
                 logger.warning("no records to write", path=str(full))
                 return False
             table = pa.Table.from_pylist(records)
-            pq.write_table(table, str(full), compression=self.compression)
+            pq.write_table(table, str(full), compression=self.compression)  # type: ignore[no-untyped-call]
             logger.info("wrote records", count=len(records), path=str(full))
             return True
         except Exception as exc:
@@ -183,7 +183,7 @@ class ParquetStorage(StorageBackend):
             if not full.exists():
                 logger.warning("parquet file not found", path=str(full))
                 return None
-            table = pq.read_table(str(full))
+            table = pq.read_table(str(full))  # type: ignore[no-untyped-call]
             return table.to_pylist()
         except Exception as exc:
             logger.error("parquet storage read failed", exc=str(exc))

--- a/src/dataenginex/secops/__init__.py
+++ b/src/dataenginex/secops/__init__.py
@@ -1,12 +1,13 @@
-"""DataSecOps — PII detection, masking, and audit logging.
+"""DataSecOps — PII detection, masking, audit logging, and outbound-call guard.
 
 Public API::
 
     from dataenginex.secops import (
-        PIIDetector, PIIField, PIIType,
+        PIIDetector, PIIField, PIIType, TextMatch,
         MaskingEngine, MaskingStrategy,
-        AuditLogger, AuditEvent,
+        AuditLogger, AuditEvent, AuditOperation,
         SecOpsGate,
+        PrivacyGuard, PrivacyGuardConfig, GuardResult, PrivacyBlocked,
     )
 """
 
@@ -14,17 +15,23 @@ from __future__ import annotations
 
 from .audit import AuditEvent, AuditLogger, AuditOperation
 from .gate import SecOpsGate
+from .guard import GuardResult, PrivacyBlocked, PrivacyGuard, PrivacyGuardConfig
 from .masking import MaskingEngine, MaskingStrategy
-from .pii import PIIDetector, PIIField, PIIType
+from .pii import PIIDetector, PIIField, PIIType, TextMatch
 
 __all__ = [
     "AuditEvent",
     "AuditLogger",
     "AuditOperation",
+    "GuardResult",
     "MaskingEngine",
     "MaskingStrategy",
     "PIIDetector",
     "PIIField",
     "PIIType",
+    "PrivacyBlocked",
+    "PrivacyGuard",
+    "PrivacyGuardConfig",
     "SecOpsGate",
+    "TextMatch",
 ]

--- a/src/dataenginex/secops/guard.py
+++ b/src/dataenginex/secops/guard.py
@@ -105,6 +105,35 @@ class PrivacyGuardConfig:
     strategies: dict[PIIType, MaskingStrategy] = field(default_factory=dict)
     local_targets: frozenset[str] = _DEFAULT_LOCAL_TARGETS
 
+    @classmethod
+    def from_dict(cls, data: dict[str, object]) -> PrivacyGuardConfig:
+        """Build a config from a loose dict (e.g. straight from ``dex.yaml``).
+
+        String values in ``strategies`` and ``local_targets`` are converted
+        to the appropriate enum / frozenset types. Unknown PII types or
+        masking strategies raise ``ValueError`` from the enum constructors.
+        """
+        raw_strategies = data.get("strategies") or {}
+        strategies: dict[PIIType, MaskingStrategy] = {}
+        if isinstance(raw_strategies, dict):
+            for k, v in raw_strategies.items():
+                strategies[PIIType(k)] = MaskingStrategy(v)
+
+        raw_targets = data.get("local_targets")
+        if raw_targets is None:
+            local_targets = _DEFAULT_LOCAL_TARGETS
+        else:
+            local_targets = frozenset(str(t) for t in raw_targets)  # type: ignore[arg-type]
+
+        return cls(
+            enabled=bool(data.get("enabled", True)),
+            allow_local=bool(data.get("allow_local", True)),
+            block_on_detect=bool(data.get("block_on_detect", False)),
+            log_all_outbound=bool(data.get("log_all_outbound", True)),
+            strategies=strategies,
+            local_targets=local_targets,
+        )
+
 
 @dataclass(frozen=True)
 class GuardResult:

--- a/src/dataenginex/secops/guard.py
+++ b/src/dataenginex/secops/guard.py
@@ -123,7 +123,9 @@ class PrivacyGuardConfig:
         if raw_targets is None:
             local_targets = _DEFAULT_LOCAL_TARGETS
         else:
-            local_targets = frozenset(str(t) for t in raw_targets)  # type: ignore[arg-type]
+            if not hasattr(raw_targets, "__iter__"):
+                raise TypeError(f"local_targets must be iterable, got {type(raw_targets)!r}")
+            local_targets = frozenset(str(t) for t in raw_targets)
 
         return cls(
             enabled=bool(data.get("enabled", True)),

--- a/src/dataenginex/secops/guard.py
+++ b/src/dataenginex/secops/guard.py
@@ -1,0 +1,250 @@
+"""PrivacyGuard — intercept outbound LLM calls; scan, mask, and audit PII.
+
+The guard sits between the user's prompt and any external LLM provider. It:
+
+  1. Scans every outbound prompt for PII via :class:`PIIDetector.scan_text`.
+  2. Masks the matches (or blocks the send entirely) per configuration.
+  3. Logs each call so users can see exactly what left their machine.
+
+Local providers (Ollama by default) are bypassed when
+:attr:`PrivacyGuardConfig.allow_local` is ``True`` — those calls never leave
+the machine in the first place. Cloud providers (OpenAI, Anthropic, etc.)
+go through full scan/mask/log.
+
+The guard is composed with a provider via
+:class:`~dataenginex.ai.routing.guarded.GuardedProvider` rather than
+modifying the provider classes directly.
+
+Example::
+
+    from dataenginex.secops import (
+        MaskingStrategy, PIIType, PrivacyGuard, PrivacyGuardConfig,
+    )
+    from dataenginex.ai.routing.guarded import GuardedProvider
+    from dataenginex.ai.routing.openai import OpenAIProvider
+
+    guard = PrivacyGuard(
+        config=PrivacyGuardConfig(
+            strategies={
+                PIIType.EMAIL: MaskingStrategy.HASH,
+                PIIType.SSN: MaskingStrategy.REDACT,
+            },
+        ),
+    )
+    provider = GuardedProvider(OpenAIProvider(api_key="..."), guard, target="openai")
+    # All prompts now flow through the guard
+    answer = provider.generate("Contact me at alice@example.com")
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+import structlog
+
+from dataenginex.secops.audit import AuditEvent, AuditLogger, AuditOperation
+from dataenginex.secops.masking import MaskingEngine, MaskingStrategy
+from dataenginex.secops.pii import PIIDetector, PIIType, TextMatch
+
+logger = structlog.get_logger()
+
+__all__ = [
+    "GuardResult",
+    "PrivacyBlocked",
+    "PrivacyGuard",
+    "PrivacyGuardConfig",
+]
+
+# Provider targets treated as local (never leave the machine).
+_DEFAULT_LOCAL_TARGETS: frozenset[str] = frozenset({"ollama", "local"})
+
+
+class PrivacyBlocked(RuntimeError):
+    """Raised when an outbound call is rejected by the guard.
+
+    Carries the original prompt's PII findings so the caller can present a
+    useful error (e.g. surface the detected types in studio's quarantine UI
+    without re-scanning).
+    """
+
+    def __init__(self, target: str, detections: tuple[TextMatch, ...]) -> None:
+        types = sorted({m.pii_type.value for m in detections})
+        super().__init__(
+            f"PrivacyGuard blocked outbound call to {target!r}: "
+            f"{len(detections)} PII match(es) ({', '.join(types)})"
+        )
+        self.target = target
+        self.detections = detections
+
+
+@dataclass
+class PrivacyGuardConfig:
+    """Behavioural configuration for :class:`PrivacyGuard`.
+
+    Attributes:
+        enabled: Master switch. When ``False`` the guard logs a warning on
+            first call and passes prompts through unchanged.
+        allow_local: When ``True`` (default), prompts to local providers
+            (``local_targets``) bypass scanning entirely.
+        block_on_detect: When ``True``, prompts containing any PII raise
+            :exc:`PrivacyBlocked` instead of being masked.
+        log_all_outbound: When ``True`` (default), every outbound call is
+            logged via structlog — and, if an :class:`AuditLogger` is
+            attached, persisted as an :class:`AuditEvent`.
+        strategies: Per-:class:`PIIType` masking strategy overrides. Types
+            absent from this map fall back to the masker's default.
+        local_targets: Provider names treated as local. Customisable so
+            self-hosted endpoints (e.g. private OpenAI-compatible servers)
+            can opt out of guarding.
+    """
+
+    enabled: bool = True
+    allow_local: bool = True
+    block_on_detect: bool = False
+    log_all_outbound: bool = True
+    strategies: dict[PIIType, MaskingStrategy] = field(default_factory=dict)
+    local_targets: frozenset[str] = _DEFAULT_LOCAL_TARGETS
+
+
+@dataclass(frozen=True)
+class GuardResult:
+    """The outcome of running :meth:`PrivacyGuard.process` on a prompt.
+
+    Attributes:
+        safe_prompt: The text that should actually be sent. Equals the
+            original when no PII was detected or the guard was bypassed.
+        detections: PII matches found in the original prompt. Empty when
+            the guard was disabled / bypassed.
+        blocked: ``True`` when ``block_on_detect`` rejected the call.
+            Callers should raise :class:`PrivacyBlocked`.
+        target: The provider name passed to :meth:`process`.
+        bypassed_local: ``True`` when the target was a local provider and
+            scanning was skipped.
+    """
+
+    safe_prompt: str
+    detections: tuple[TextMatch, ...]
+    target: str
+    blocked: bool = False
+    bypassed_local: bool = False
+
+
+class PrivacyGuard:
+    """Pre-send PII interception for outbound LLM calls.
+
+    Compose with a :class:`~dataenginex.ai.routing.router.BaseProvider` via
+    :class:`~dataenginex.ai.routing.guarded.GuardedProvider`, or call
+    :meth:`process` directly for custom integrations.
+
+    Parameters:
+        config: Behavioural config. Defaults to a sensible "mask + log"
+            setup with no per-type strategy overrides.
+        detector: PII detector instance. A default :class:`PIIDetector`
+            is created if omitted.
+        masker: Masking engine. A default :class:`MaskingEngine`
+            (REDACT strategy) is created if omitted.
+        audit_logger: Optional :class:`AuditLogger`. When provided, every
+            non-bypassed call writes an audit row (in addition to the
+            structlog message).
+    """
+
+    def __init__(
+        self,
+        config: PrivacyGuardConfig | None = None,
+        detector: PIIDetector | None = None,
+        masker: MaskingEngine | None = None,
+        audit_logger: AuditLogger | None = None,
+    ) -> None:
+        self.config = config or PrivacyGuardConfig()
+        self._detector = detector or PIIDetector()
+        self._masker = masker or MaskingEngine(default_strategy=MaskingStrategy.REDACT)
+        self._audit = audit_logger
+        self._warned_disabled = False
+
+    def process(self, prompt: str, *, target: str = "unknown") -> GuardResult:
+        """Scan ``prompt`` for PII and return the (possibly masked) safe form.
+
+        Behaviour:
+          - Guard disabled → pass-through (logs a one-time warning).
+          - ``allow_local`` set and target is local → pass-through.
+          - Otherwise: scan, then either mask or block, then log.
+        """
+        if not self.config.enabled:
+            if not self._warned_disabled:
+                self._warned_disabled = True
+                logger.warning(
+                    "privacy_guard.disabled",
+                    note="all outbound prompts pass unmodified",
+                )
+            return GuardResult(safe_prompt=prompt, detections=(), target=target)
+
+        if self.config.allow_local and self._is_local(target):
+            return GuardResult(
+                safe_prompt=prompt,
+                detections=(),
+                target=target,
+                bypassed_local=True,
+            )
+
+        matches = self._detector.scan_text(prompt)
+        if not matches:
+            self._log(target, original=prompt, safe=prompt, matches=(), blocked=False)
+            return GuardResult(safe_prompt=prompt, detections=(), target=target)
+
+        detections = tuple(matches)
+        if self.config.block_on_detect:
+            self._log(target, original=prompt, safe="", matches=detections, blocked=True)
+            return GuardResult(
+                safe_prompt=prompt,
+                detections=detections,
+                target=target,
+                blocked=True,
+            )
+
+        safe = self._masker.mask_text(prompt, list(matches), strategies=self.config.strategies)
+        self._log(target, original=prompt, safe=safe, matches=detections, blocked=False)
+        return GuardResult(safe_prompt=safe, detections=detections, target=target)
+
+    def _is_local(self, target: str) -> bool:
+        """Return ``True`` if ``target`` is configured as local."""
+        return target.lower() in self.config.local_targets
+
+    def _log(
+        self,
+        target: str,
+        *,
+        original: str,
+        safe: str,
+        matches: tuple[TextMatch, ...],
+        blocked: bool,
+    ) -> None:
+        """Emit a structured log entry and (optionally) an audit row."""
+        if not self.config.log_all_outbound:
+            return
+        types = sorted({m.pii_type.value for m in matches})
+        logger.info(
+            "privacy_guard.outbound",
+            target=target,
+            blocked=blocked,
+            pii_count=len(matches),
+            pii_types=types,
+            chars_in=len(original),
+            chars_out=len(safe),
+        )
+        if self._audit is not None and matches:
+            operation = AuditOperation.PII_ACCESS if blocked else AuditOperation.PII_MASK
+            self._audit.log(
+                AuditEvent(
+                    operation=operation,
+                    dataset_name=f"outbound:{target}",
+                    pii_fields=types,
+                    record_count=1,
+                    actor="privacy_guard",
+                    metadata={
+                        "blocked": blocked,
+                        "match_count": len(matches),
+                        "chars_in": len(original),
+                        "chars_out": len(safe),
+                    },
+                )
+            )

--- a/src/dataenginex/secops/masking.py
+++ b/src/dataenginex/secops/masking.py
@@ -12,7 +12,10 @@ from __future__ import annotations
 
 import hashlib
 from enum import StrEnum
-from typing import Any, assert_never
+from typing import TYPE_CHECKING, Any, assert_never
+
+if TYPE_CHECKING:
+    from dataenginex.secops.pii import PIIType, TextMatch
 
 __all__ = [
     "MaskingEngine",
@@ -85,6 +88,34 @@ class MaskingEngine:
     ) -> list[dict[str, Any]]:
         """Return a masked copy of every record in *records*."""
         return [self.mask_record(r, pii_fields) for r in records]
+
+    def mask_text(
+        self,
+        text: str,
+        matches: list[TextMatch],
+        strategies: dict[PIIType, MaskingStrategy] | None = None,
+    ) -> str:
+        """Return *text* with every match in *matches* replaced.
+
+        Used by :class:`~dataenginex.secops.guard.PrivacyGuard` to redact PII
+        from outbound LLM prompts. ``strategies`` maps each :class:`PIIType`
+        to its masking strategy; PII types absent from the map fall back to
+        ``self._default``.
+
+        Replacements are applied from right to left so earlier indices stay
+        valid as the string shrinks/grows.
+        """
+        if not matches:
+            return text
+        strategy_map = strategies or {}
+        # Apply replacements right-to-left to preserve indices
+        ordered = sorted(matches, key=lambda m: m.start, reverse=True)
+        result = text
+        for match in ordered:
+            strategy = strategy_map.get(match.pii_type, self._default)
+            replacement = self._apply(match.value, strategy)
+            result = result[: match.start] + replacement + result[match.end :]
+        return result
 
     def _apply(self, value: Any, strategy: MaskingStrategy) -> str:
         """Apply a single masking strategy to *value*."""

--- a/src/dataenginex/secops/pii.py
+++ b/src/dataenginex/secops/pii.py
@@ -19,6 +19,7 @@ __all__ = [
     "PIIDetector",
     "PIIField",
     "PIIType",
+    "TextMatch",
 ]
 
 
@@ -51,6 +52,28 @@ class PIIField:
     pii_type: PIIType
     confidence: float
     sample: str = ""
+
+
+@dataclass(frozen=True)
+class TextMatch:
+    """A PII match found in a span of free-form text.
+
+    Used by ``PIIDetector.scan_text`` and ``MaskingEngine.mask_text`` for
+    prompt-level scanning (the call-level path used by ``PrivacyGuard``).
+
+    Attributes:
+        pii_type: Detected PII category.
+        value: The matched substring (kept verbatim for masking).
+        start: Inclusive start index into the source text.
+        end: Exclusive end index into the source text.
+        confidence: Detection confidence 0.0–1.0.
+    """
+
+    pii_type: PIIType
+    value: str
+    start: int
+    end: int
+    confidence: float = 0.0
 
 
 # Name-based hints: if the field name contains any of these tokens,
@@ -147,6 +170,35 @@ class PIIDetector:
         """Return just the field names that contain PII."""
         return set(self.scan_dataset(records).keys())
 
+    def scan_text(self, text: str) -> list[TextMatch]:
+        """Find all PII spans in a free-form string.
+
+        Runs every value-based regex pattern that meets the configured
+        confidence threshold over *text* and returns matches sorted by
+        start position. Overlapping spans from different patterns are
+        deduplicated, keeping the leftmost / highest-confidence match.
+
+        This is the scanner used by :class:`PrivacyGuard` for outbound
+        LLM prompts.
+        """
+        if not text:
+            return []
+        matches: list[TextMatch] = []
+        for pii_type, pattern, confidence in _VALUE_PATTERNS:
+            if confidence < self._threshold:
+                continue
+            for m in pattern.finditer(text):
+                matches.append(
+                    TextMatch(
+                        pii_type=pii_type,
+                        value=m.group(),
+                        start=m.start(),
+                        end=m.end(),
+                        confidence=confidence,
+                    )
+                )
+        return _dedupe_overlapping(matches)
+
     def _check_field(self, field_name: str, value: Any) -> PIIField | None:
         """Check a single field by name then by value pattern."""
         lower_name = field_name.lower()
@@ -183,3 +235,25 @@ def _safe_sample(value: Any, keep_last: int = 4) -> str:
     if len(s) <= keep_last:
         return "*" * len(s)
     return "*" * (len(s) - keep_last) + s[-keep_last:]
+
+
+def _dedupe_overlapping(matches: list[TextMatch]) -> list[TextMatch]:
+    """Sort *matches* by start; drop any that overlap an earlier kept match.
+
+    When two patterns hit the same span (e.g. credit card and phone), the
+    higher-confidence one is preferred. Stable for equal confidence —
+    earlier-detected wins.
+    """
+    if not matches:
+        return []
+    # Sort by start, then by confidence desc so highest confidence wins for ties
+    sorted_matches = sorted(matches, key=lambda m: (m.start, -m.confidence))
+    kept: list[TextMatch] = []
+    for m in sorted_matches:
+        if kept and m.start < kept[-1].end:
+            # Overlaps the previously kept span — skip unless strictly higher confidence
+            if m.confidence > kept[-1].confidence:
+                kept[-1] = m
+            continue
+        kept.append(m)
+    return kept

--- a/tests/unit/test_config_schema_extended.py
+++ b/tests/unit/test_config_schema_extended.py
@@ -1,0 +1,299 @@
+"""Tests for dataenginex.config.schema — all Pydantic config models."""
+
+from __future__ import annotations
+
+import pytest
+
+from dataenginex.config.schema import (
+    AgentConfig,
+    AiConfig,
+    AuditConfig,
+    CollectionConfig,
+    DataConfig,
+    DexConfig,
+    DriftConfig,
+    ExperimentConfig,
+    GuardConfig,
+    LLMConfig,
+    MlConfig,
+    ObservabilityConfig,
+    PiiConfig,
+    PipelineConfig,
+    ProjectConfig,
+    QualityCheckConfig,
+    RetrievalConfig,
+    SecopsConfig,
+    SourceConfig,
+    TrackerConfig,
+    TransformStepConfig,
+    VectorStoreConfig,
+)
+
+
+class TestProjectConfig:
+    def test_minimal(self) -> None:
+        c = ProjectConfig(name="my-project")
+        assert c.name == "my-project"
+        assert c.version == "0.1.0"
+        assert c.description == ""
+
+    def test_full(self) -> None:
+        c = ProjectConfig(name="test", version="2.0.0", description="A project")
+        assert c.version == "2.0.0"
+
+    def test_name_required(self) -> None:
+        from pydantic import ValidationError
+
+        with pytest.raises(ValidationError):
+            ProjectConfig()  # type: ignore[call-arg]
+
+
+class TestSourceConfig:
+    def test_minimal(self) -> None:
+        s = SourceConfig(type="csv")
+        assert s.type == "csv"
+        assert s.path is None
+
+    def test_with_path(self) -> None:
+        s = SourceConfig(type="csv", path="/data/file.csv")
+        assert s.path == "/data/file.csv"
+
+    def test_all_fields(self) -> None:
+        s = SourceConfig(
+            type="postgres",
+            path=None,
+            query="SELECT * FROM table",
+            url="postgresql://user:pass@host/db",
+            connection={"sslmode": "require"},
+            options={"timeout": 30},
+        )
+        assert s.type == "postgres"
+        assert s.query == "SELECT * FROM table"
+
+
+class TestTransformStepConfig:
+    def test_filter_transform(self) -> None:
+        t = TransformStepConfig(type="filter", condition="age > 18")
+        assert t.type == "filter"
+        assert t.condition == "age > 18"
+
+    def test_sql_transform(self) -> None:
+        t = TransformStepConfig(type="sql", sql="SELECT * FROM _data LIMIT 10")
+        assert t.sql == "SELECT * FROM _data LIMIT 10"
+
+    def test_cast_transform(self) -> None:
+        t = TransformStepConfig(type="cast", columns={"age": "int"})
+        assert t.columns == {"age": "int"}
+
+    def test_derive_transform(self) -> None:
+        t = TransformStepConfig(type="derive", name="full_name", expression="first + ' ' + last")
+        assert t.name == "full_name"
+
+    def test_deduplicate_transform(self) -> None:
+        t = TransformStepConfig(type="deduplicate", key=["id", "email"])
+        assert t.key == ["id", "email"]
+
+
+class TestQualityCheckConfig:
+    def test_defaults(self) -> None:
+        q = QualityCheckConfig()
+        assert q.completeness is None
+        assert q.uniqueness is None
+
+    def test_with_values(self) -> None:
+        q = QualityCheckConfig(completeness=0.95, uniqueness=["id", "email"])
+        assert q.completeness is not None and q.completeness > 0.9
+        assert q.uniqueness is not None and "id" in q.uniqueness
+
+
+class TestPipelineConfig:
+    def test_minimal(self) -> None:
+        p = PipelineConfig(source="raw_data")
+        assert p.source == "raw_data"
+        assert p.transforms == []
+        assert p.schedule is None
+
+    def test_with_schedule(self) -> None:
+        p = PipelineConfig(source="data", schedule="0 * * * *")
+        assert p.schedule == "0 * * * *"
+
+    def test_with_transforms(self) -> None:
+        t = TransformStepConfig(type="filter", condition="x > 0")
+        p = PipelineConfig(source="data", transforms=[t])
+        assert len(p.transforms) == 1
+
+    def test_with_depends_on(self) -> None:
+        p = PipelineConfig(source="data", depends_on=["bronze_pipeline"])
+        assert "bronze_pipeline" in p.depends_on
+
+
+class TestDataConfig:
+    def test_defaults(self) -> None:
+        d = DataConfig()
+        assert d.engine == "duckdb"
+        assert d.sources == {}
+        assert d.pipelines == {}
+
+    def test_with_sources(self) -> None:
+        d = DataConfig(sources={"raw": SourceConfig(type="csv", path="data.csv")})
+        assert "raw" in d.sources
+
+
+class TestTrackerConfig:
+    def test_defaults(self) -> None:
+        t = TrackerConfig()
+        assert t.backend is not None
+
+    def test_custom_backend(self) -> None:
+        t = TrackerConfig(backend="mlflow")
+        assert t.backend == "mlflow"
+
+
+class TestExperimentConfig:
+    def test_minimal(self) -> None:
+        e = ExperimentConfig(target="label")
+        assert e.target == "label"
+        assert e.features == []
+
+    def test_with_features(self) -> None:
+        e = ExperimentConfig(
+            target="churn", features=["age", "spend"], params={"n_estimators": 100}
+        )
+        assert "age" in e.features
+        assert e.params["n_estimators"] == 100
+
+
+class TestDriftConfig:
+    def test_defaults(self) -> None:
+        d = DriftConfig()
+        assert d.monitor == []
+
+    def test_with_columns(self) -> None:
+        d = DriftConfig(monitor=["spend", "age"])
+        assert len(d.monitor) == 2
+
+
+class TestMlConfig:
+    def test_defaults(self) -> None:
+        m = MlConfig()
+        assert m.experiments == {}
+
+    def test_with_experiment(self) -> None:
+        m = MlConfig(experiments={"churn": ExperimentConfig(target="churned")})
+        assert "churn" in m.experiments
+
+
+class TestLLMConfig:
+    def test_defaults(self) -> None:
+        c = LLMConfig()
+        assert c.provider is not None
+        assert c.model is not None
+
+    def test_custom(self) -> None:
+        c = LLMConfig(provider="openai", model="gpt-4o")
+        assert c.provider == "openai"
+        assert c.model == "gpt-4o"
+
+
+class TestRetrievalConfig:
+    def test_defaults(self) -> None:
+        r = RetrievalConfig()
+        assert r.top_k > 0
+
+    def test_custom(self) -> None:
+        r = RetrievalConfig(strategy="bm25", top_k=10)
+        assert r.strategy == "bm25"
+
+
+class TestVectorStoreConfig:
+    def test_defaults(self) -> None:
+        v = VectorStoreConfig()
+        assert v.backend is not None
+
+
+class TestCollectionConfig:
+    def test_defaults(self) -> None:
+        c = CollectionConfig()
+        assert c.chunk_size > 0
+
+
+class TestAgentConfig:
+    def test_minimal(self) -> None:
+        a = AgentConfig(system_prompt="You are helpful.")
+        assert a.system_prompt == "You are helpful."
+        assert a.runtime == "builtin"
+        assert a.tools == []
+
+    def test_with_tools(self) -> None:
+        a = AgentConfig(system_prompt="s", tools=["query", "pipeline_status"])
+        assert "query" in a.tools
+
+
+class TestAiConfig:
+    def test_defaults(self) -> None:
+        a = AiConfig()
+        assert a.agents == {}
+
+    def test_with_agent(self) -> None:
+        a = AiConfig(agents={"assistant": AgentConfig(system_prompt="Hello")})
+        assert "assistant" in a.agents
+
+
+class TestPiiConfig:
+    def test_defaults(self) -> None:
+        p = PiiConfig()
+        assert p.scan is not None
+
+
+class TestAuditConfig:
+    def test_defaults(self) -> None:
+        a = AuditConfig()
+        assert a.enabled is not None
+
+
+class TestGuardConfig:
+    def test_defaults(self) -> None:
+        g = GuardConfig()
+        assert g.enabled is not None
+
+
+class TestSecopsConfig:
+    def test_defaults(self) -> None:
+        s = SecopsConfig()
+        assert s.pii is not None
+        assert s.audit is not None
+        assert s.guard is not None
+
+
+class TestObservabilityConfig:
+    def test_defaults(self) -> None:
+        o = ObservabilityConfig()
+        assert o.metrics is not None
+
+
+class TestDexConfig:
+    def test_minimal(self) -> None:
+        c = DexConfig(project=ProjectConfig(name="test"))
+        assert c.project.name == "test"
+        assert c.data is not None
+        assert c.ml is not None
+        assert c.ai is not None
+        assert c.secops is not None
+
+    def test_project_required(self) -> None:
+        from pydantic import ValidationError
+
+        with pytest.raises(ValidationError):
+            DexConfig()  # type: ignore[call-arg]
+
+    def test_full_config(self) -> None:
+        c = DexConfig(
+            project=ProjectConfig(name="full", version="1.0.0"),
+            data=DataConfig(sources={"src": SourceConfig(type="csv")}),
+            ml=MlConfig(),
+            ai=AiConfig(),
+            secops=SecopsConfig(),
+            observability=ObservabilityConfig(),
+        )
+        assert c.project.name == "full"
+        assert "src" in c.data.sources

--- a/tests/unit/test_core_quality.py
+++ b/tests/unit/test_core_quality.py
@@ -1,0 +1,264 @@
+"""Tests for dataenginex.core.quality — QualityGate, QualityStore and friends."""
+
+from __future__ import annotations
+
+import pytest
+
+from dataenginex.core.medallion_architecture import DataLayer
+from dataenginex.core.quality import (
+    QualityDimension,
+    QualityGate,
+    QualityResult,
+    QualityStore,
+)
+
+# ── QualityDimension ──────────────────────────────────────────────────────────
+
+
+class TestQualityDimension:
+    def test_all_values(self) -> None:
+        values = {d.value for d in QualityDimension}
+        assert values == {"completeness", "accuracy", "consistency", "timeliness", "uniqueness"}
+
+    def test_str_enum(self) -> None:
+        assert QualityDimension.COMPLETENESS == "completeness"
+        assert QualityDimension.UNIQUENESS == "uniqueness"
+
+
+# ── QualityResult ─────────────────────────────────────────────────────────────
+
+
+class TestQualityResult:
+    def _make(self, passed: bool = True, score: float = 0.9) -> QualityResult:
+        return QualityResult(
+            passed=passed,
+            layer="silver",
+            quality_score=score,
+            threshold=0.75,
+            record_count=100,
+            valid_count=90,
+            dimensions={"completeness": 0.9, "uniqueness": 0.95},
+        )
+
+    def test_fields_accessible(self) -> None:
+        r = self._make()
+        assert r.passed is True
+        assert r.layer == "silver"
+        assert r.record_count == 100
+
+    def test_to_dict_structure(self) -> None:
+        d = self._make().to_dict()
+        assert d["passed"] is True
+        assert d["layer"] == "silver"
+        assert d["quality_score"] == 0.9
+        assert "dimensions" in d
+        assert "evaluated_at" in d
+
+    def test_to_dict_rounding(self) -> None:
+        r = QualityResult(
+            passed=True,
+            layer="bronze",
+            quality_score=0.123456789,
+            threshold=0.0,
+            record_count=1,
+            valid_count=1,
+            dimensions={"completeness": 0.999999},
+        )
+        d = r.to_dict()
+        assert len(str(d["quality_score"]).split(".")[-1]) <= 4
+
+    def test_frozen_immutable(self) -> None:
+        r = self._make()
+        with pytest.raises((AttributeError, TypeError)):
+            r.passed = False  # type: ignore[misc]
+
+    def test_profile_defaults_none(self) -> None:
+        r = self._make()
+        assert r.profile is None
+
+
+# ── QualityStore ──────────────────────────────────────────────────────────────
+
+
+class TestQualityStore:
+    def _make_result(self, layer: str, score: float, passed: bool = True) -> QualityResult:
+        return QualityResult(
+            passed=passed,
+            layer=layer,
+            quality_score=score,
+            threshold=0.75,
+            record_count=10,
+            valid_count=9,
+            dimensions={},
+        )
+
+    def test_init_empty(self) -> None:
+        store = QualityStore()
+        assert store.latest("bronze") is None
+        assert store.latest("silver") is None
+
+    def test_record_and_latest(self) -> None:
+        store = QualityStore()
+        r = self._make_result("silver", 0.85)
+        store.record(r)
+        assert store.latest("silver") is r
+
+    def test_latest_returns_most_recent(self) -> None:
+        store = QualityStore()
+        r1 = self._make_result("gold", 0.80)
+        r2 = self._make_result("gold", 0.95)
+        store.record(r1)
+        store.record(r2)
+        assert store.latest("gold") is r2
+
+    def test_unknown_layer_in_record(self) -> None:
+        store = QualityStore()
+        r = self._make_result("custom_layer", 0.7)
+        store.record(r)
+        assert store.latest("custom_layer") is r
+
+    def test_summary_all_layers_present(self) -> None:
+        store = QualityStore()
+        summary = store.summary()
+        assert set(summary["layer_scores"].keys()) == {"bronze", "silver", "gold"}
+        assert summary["overall_score"] == 0.0
+
+    def test_summary_with_data(self) -> None:
+        store = QualityStore()
+        store.record(self._make_result("bronze", 0.6))
+        store.record(self._make_result("silver", 0.8))
+        store.record(self._make_result("gold", 0.9))
+        s = store.summary()
+        assert s["layer_scores"]["bronze"] == 0.6
+        assert s["layer_scores"]["silver"] == 0.8
+        assert s["overall_score"] > 0
+
+    def test_summary_includes_all_dimensions(self) -> None:
+        store = QualityStore()
+        store.record(
+            QualityResult(
+                passed=True,
+                layer="silver",
+                quality_score=0.8,
+                threshold=0.75,
+                record_count=10,
+                valid_count=9,
+                dimensions={"completeness": 0.9},
+            )
+        )
+        s = store.summary()
+        for dim in QualityDimension:
+            assert dim.value in s["dimensions"]
+
+    def test_history_empty(self) -> None:
+        store = QualityStore()
+        assert store.history("bronze") == []
+
+    def test_history_returns_dicts(self) -> None:
+        store = QualityStore()
+        store.record(self._make_result("bronze", 0.7))
+        store.record(self._make_result("bronze", 0.8))
+        h = store.history("bronze")
+        assert len(h) == 2
+        assert all(isinstance(entry, dict) for entry in h)
+
+    def test_history_limit(self) -> None:
+        store = QualityStore()
+        for score in [0.6, 0.7, 0.8, 0.9]:
+            store.record(self._make_result("silver", score))
+        assert len(store.history("silver", limit=2)) == 2
+
+    def test_history_unknown_layer(self) -> None:
+        store = QualityStore()
+        assert store.history("unknown") == []
+
+
+# ── QualityGate ───────────────────────────────────────────────────────────────
+
+
+class TestQualityGateEmptyBatch:
+    def test_empty_records_passes(self) -> None:
+        gate = QualityGate()
+        result = gate.evaluate([], layer=DataLayer.BRONZE)
+        assert result.passed is True
+        assert result.record_count == 0
+
+    def test_empty_records_with_store(self) -> None:
+        store = QualityStore()
+        gate = QualityGate(store=store)
+        gate.evaluate([], layer=DataLayer.SILVER)
+        assert store.latest("silver") is not None
+
+    def test_store_property(self) -> None:
+        store = QualityStore()
+        gate = QualityGate(store=store)
+        assert gate.store is store
+
+    def test_no_store_property(self) -> None:
+        gate = QualityGate()
+        assert gate.store is None
+
+
+class TestQualityGateWithRecords:
+    def _records(self, n: int = 5) -> list[dict]:
+        return [{"id": str(i), "name": f"item_{i}", "value": i} for i in range(n)]
+
+    def test_basic_evaluation(self) -> None:
+        gate = QualityGate()
+        result = gate.evaluate(self._records(), layer=DataLayer.SILVER)
+        assert result.record_count == 5
+        assert result.layer == "silver"
+        assert 0.0 <= result.quality_score <= 1.0
+
+    def test_passes_bronze_always(self) -> None:
+        gate = QualityGate()
+        result = gate.evaluate(self._records(), layer=DataLayer.BRONZE)
+        assert result.passed is True
+
+    def test_dimensions_present(self) -> None:
+        gate = QualityGate()
+        result = gate.evaluate(self._records(), layer=DataLayer.BRONZE)
+        for dim in QualityDimension:
+            assert dim.value in result.dimensions
+
+    def test_required_fields_completeness(self) -> None:
+        gate = QualityGate(required_fields={"id", "name"})
+        records = [{"id": "1", "name": "a"}, {"id": None, "name": "b"}]
+        result = gate.evaluate(records, layer=DataLayer.BRONZE)
+        assert result.valid_count < result.record_count
+
+    def test_required_fields_override_at_call_site(self) -> None:
+        gate = QualityGate()
+        records = [{"id": "1"}, {"id": None}]
+        result = gate.evaluate(records, layer=DataLayer.BRONZE, required_fields={"id"})
+        assert result.valid_count == 1
+
+    def test_injected_scorer(self) -> None:
+        gate = QualityGate(scorer=lambda r: float(r.get("value", 0)) / 10)
+        records = [{"value": 8}, {"value": 6}]
+        result = gate.evaluate(records, layer=DataLayer.BRONZE)
+        assert result.dimensions["accuracy"] > 0.0
+
+    def test_uniqueness_key(self) -> None:
+        gate = QualityGate(uniqueness_key="name")
+        records = [{"name": "dup"}, {"name": "dup"}, {"name": "unique"}]
+        result = gate.evaluate(records, layer=DataLayer.BRONZE)
+        assert result.dimensions["uniqueness"] < 1.0
+
+    def test_result_stored_in_store(self) -> None:
+        store = QualityStore()
+        gate = QualityGate(store=store)
+        gate.evaluate(self._records(), layer=DataLayer.GOLD)
+        assert store.latest("gold") is not None
+
+    def test_gold_threshold_may_fail(self) -> None:
+        gate = QualityGate(scorer=lambda _: 0.0)
+        records = [{"id": None}] * 10
+        result = gate.evaluate(records, layer=DataLayer.GOLD)
+        assert result.threshold == 0.90
+        assert result.passed is False
+
+    def test_profile_attached(self) -> None:
+        gate = QualityGate()
+        result = gate.evaluate(self._records(), layer=DataLayer.BRONZE)
+        assert result.profile is not None

--- a/tests/unit/test_core_schemas_extended.py
+++ b/tests/unit/test_core_schemas_extended.py
@@ -1,0 +1,202 @@
+"""Tests for core/schemas.py (API response models) and core/exceptions.py."""
+
+from __future__ import annotations
+
+import pytest
+
+from dataenginex.core.exceptions import (
+    AgentError,
+    BackendNotInstalledError,
+    ConfigError,
+    ConfigValidationError,
+    DataEngineXError,
+    LLMProviderError,
+    PipelineError,
+    PipelineStepError,
+    RegistryError,
+    ServingError,
+    TrainingError,
+)
+from dataenginex.core.schemas import (
+    ComponentStatus,
+    EchoRequest,
+    EchoResponse,
+    ErrorDetail,
+    ErrorResponse,
+    HealthResponse,
+    ReadinessResponse,
+    RootResponse,
+    StartupResponse,
+)
+
+# ── core/schemas.py ───────────────────────────────────────────────────────────
+
+
+class TestRootResponse:
+    def test_fields(self) -> None:
+        r = RootResponse(message="hello", version="1.0.0")
+        assert r.message == "hello"
+        assert r.version == "1.0.0"
+
+    def test_serialise(self) -> None:
+        r = RootResponse(message="DataEngineX API", version="0.1.0")
+        d = r.model_dump()
+        assert d["message"] == "DataEngineX API"
+
+
+class TestHealthResponse:
+    def test_status_field(self) -> None:
+        h = HealthResponse(status="alive")
+        assert h.status == "alive"
+
+    def test_json_round_trip(self) -> None:
+        h = HealthResponse(status="ok")
+        assert HealthResponse.model_validate_json(h.model_dump_json()).status == "ok"
+
+
+class TestStartupResponse:
+    def test_fields(self) -> None:
+        s = StartupResponse(status="started")
+        assert s.status == "started"
+
+
+class TestComponentStatus:
+    def test_minimal(self) -> None:
+        c = ComponentStatus(name="db", status="healthy")
+        assert c.name == "db"
+        assert c.message is None
+        assert c.duration_ms is None
+
+    def test_with_all_fields(self) -> None:
+        c = ComponentStatus(name="cache", status="degraded", message="slow", duration_ms=42.5)
+        assert c.duration_ms == 42.5
+
+    def test_serialise(self) -> None:
+        c = ComponentStatus(name="x", status="ok")
+        d = c.model_dump()
+        assert "name" in d and "status" in d
+
+
+class TestReadinessResponse:
+    def test_fields(self) -> None:
+        r = ReadinessResponse(status="ready", components=[])
+        assert r.status == "ready"
+        assert r.components == []
+
+    def test_with_components(self) -> None:
+        c = ComponentStatus(name="db", status="ok")
+        r = ReadinessResponse(status="ready", components=[c])
+        assert len(r.components) == 1
+
+
+class TestErrorDetail:
+    def test_fields(self) -> None:
+        e = ErrorDetail(field="name", message="required")
+        assert e.field == "name"
+        assert e.message == "required"
+
+
+class TestErrorResponse:
+    def test_fields(self) -> None:
+        e = ErrorResponse(error="not_found", message="Resource not found")
+        assert e.error == "not_found"
+        assert e.details is None
+
+    def test_with_details(self) -> None:
+        detail = ErrorDetail(field="id", message="invalid")
+        e = ErrorResponse(error="bad_request", message="Validation error", details=[detail])
+        assert len(e.details) == 1  # type: ignore[arg-type]
+
+    def test_error_detail_optional_fields(self) -> None:
+        d = ErrorDetail(message="required field missing")
+        assert d.field is None
+        assert d.type is None
+
+
+class TestEchoModels:
+    def test_echo_request(self) -> None:
+        req = EchoRequest(message="ping")
+        assert req.message == "ping"
+        assert req.count == 1
+
+    def test_echo_response(self) -> None:
+        resp = EchoResponse(message="pong", count=2, echo=["pong", "pong"])
+        assert resp.message == "pong"
+        assert len(resp.echo) == 2
+
+
+# ── core/exceptions.py ────────────────────────────────────────────────────────
+
+
+class TestExceptionHierarchyExtended:
+    def test_base_is_exception(self) -> None:
+        e = DataEngineXError("test")
+        assert isinstance(e, Exception)
+
+    def test_config_error(self) -> None:
+        e = ConfigError("bad config")
+        assert isinstance(e, DataEngineXError)
+
+    def test_config_validation_error_fields(self) -> None:
+        e = ConfigValidationError("field.name", "must be a string")
+        assert e.field == "field.name"
+        assert e.message == "must be a string"
+        assert "field.name" in str(e)
+        assert isinstance(e, ConfigError)
+
+    def test_pipeline_error(self) -> None:
+        e = PipelineError("pipeline blew up")
+        assert isinstance(e, DataEngineXError)
+
+    def test_pipeline_step_error_full(self) -> None:
+        e = PipelineStepError("transform", "null value", pipeline="ingest")
+        assert e.step == "transform"
+        assert e.pipeline == "ingest"
+        assert "[ingest]" in str(e)
+        assert isinstance(e, PipelineError)
+
+    def test_pipeline_step_error_no_pipeline(self) -> None:
+        e = PipelineStepError("load", "timeout")
+        assert e.pipeline == ""
+        assert "[" not in str(e)
+
+    def test_pipeline_step_error_message_kwarg(self) -> None:
+        e = PipelineStepError("step", message="via message kwarg")
+        assert e.cause == "via message kwarg"
+
+    def test_registry_error(self) -> None:
+        e = RegistryError("unknown backend")
+        assert isinstance(e, DataEngineXError)
+
+    def test_backend_not_installed(self) -> None:
+        e = BackendNotInstalledError("qdrant", "qdrant")
+        assert e.backend == "qdrant"
+        assert e.extra == "qdrant"
+        assert "pip install" in str(e)
+
+    def test_training_error(self) -> None:
+        e = TrainingError("model failed")
+        assert isinstance(e, DataEngineXError)
+
+    def test_serving_error(self) -> None:
+        e = ServingError("serving failed")
+        assert isinstance(e, DataEngineXError)
+
+    def test_agent_error(self) -> None:
+        e = AgentError("agent crashed")
+        assert isinstance(e, DataEngineXError)
+
+    def test_llm_provider_error(self) -> None:
+        e = LLMProviderError("openai", "rate limited")
+        assert e.provider == "openai"
+        assert "openai" in str(e)
+        assert "rate limited" in str(e)
+        assert isinstance(e, AgentError)
+
+    def test_raise_and_catch_base(self) -> None:
+        with pytest.raises(DataEngineXError):
+            raise ConfigValidationError("x", "bad")
+
+    def test_raise_and_catch_specific(self) -> None:
+        with pytest.raises(ConfigValidationError):
+            raise ConfigValidationError("x", "bad")

--- a/tests/unit/test_dbt_connector.py
+++ b/tests/unit/test_dbt_connector.py
@@ -1,0 +1,172 @@
+"""Tests for dataenginex.data.connectors.dbt — DbtConnector."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from subprocess import CompletedProcess
+from unittest.mock import patch
+
+import duckdb
+import pytest
+
+from dataenginex.data.connectors.dbt import DbtConnector
+
+
+@pytest.fixture()
+def dbt_project(tmp_path: Path) -> Path:
+    """Create a minimal dbt project directory structure."""
+    (tmp_path / "dbt_project.yml").write_text("name: test_project\n")
+    return tmp_path
+
+
+@pytest.fixture()
+def dbt_database(dbt_project: Path) -> Path:
+    """Create a DuckDB file with a model table pre-populated."""
+    db_path = dbt_project / "dev.duckdb"
+    conn = duckdb.connect(str(db_path))
+    conn.execute("CREATE TABLE users_cleaned AS SELECT 1 AS id, 'alice' AS name")
+    conn.close()
+    return db_path
+
+
+def _ok_run(*args: object, **kwargs: object) -> CompletedProcess[str]:
+    return CompletedProcess(args=[], returncode=0, stdout="", stderr="")
+
+
+def _fail_run(*args: object, **kwargs: object) -> CompletedProcess[str]:
+    return CompletedProcess(args=[], returncode=1, stdout="Error output", stderr="stderr msg")
+
+
+class TestDbtConnectorImportGuard:
+    def test_raises_import_error_when_dbt_missing(self, tmp_path: Path) -> None:
+        with (
+            patch("dataenginex.data.connectors.dbt._DBT_AVAILABLE", False),
+            pytest.raises(ImportError, match="dbt CLI not found"),
+        ):
+            DbtConnector(project_dir=str(tmp_path), model="my_model")
+
+    def test_registered_as_dbt(self) -> None:
+        from dataenginex.data.connectors import connector_registry
+
+        cls = connector_registry.get("dbt")
+        assert cls is DbtConnector
+
+
+class TestDbtConnectorConnect:
+    def test_connect_succeeds_when_project_exists(self, dbt_project: Path) -> None:
+        with patch("dataenginex.data.connectors.dbt._DBT_AVAILABLE", True):
+            c = DbtConnector(project_dir=str(dbt_project), model="users_cleaned")
+            c.connect()  # should not raise
+
+    def test_connect_raises_when_project_missing(self, tmp_path: Path) -> None:
+        with patch("dataenginex.data.connectors.dbt._DBT_AVAILABLE", True):
+            c = DbtConnector(project_dir=str(tmp_path), model="m")
+            with pytest.raises(FileNotFoundError, match="dbt project not found"):
+                c.connect()
+
+    def test_disconnect_is_idempotent(self, dbt_project: Path) -> None:
+        with patch("dataenginex.data.connectors.dbt._DBT_AVAILABLE", True):
+            c = DbtConnector(project_dir=str(dbt_project), model="m")
+            c.disconnect()
+            c.disconnect()  # should not raise
+
+    def test_health_check_true_when_project_exists(self, dbt_project: Path) -> None:
+        with patch("dataenginex.data.connectors.dbt._DBT_AVAILABLE", True):
+            c = DbtConnector(project_dir=str(dbt_project), model="m")
+            assert c.health_check() is True
+
+    def test_health_check_false_when_project_missing(self, tmp_path: Path) -> None:
+        with patch("dataenginex.data.connectors.dbt._DBT_AVAILABLE", True):
+            c = DbtConnector(project_dir=str(tmp_path), model="m")
+            assert c.health_check() is False
+
+
+class TestDbtConnectorRead:
+    def test_read_runs_dbt_and_returns_rows(self, dbt_project: Path, dbt_database: Path) -> None:
+        with (
+            patch("dataenginex.data.connectors.dbt._DBT_AVAILABLE", True),
+            patch("subprocess.run", side_effect=_ok_run),
+        ):
+            c = DbtConnector(project_dir=str(dbt_project), model="users_cleaned")
+            rows = c.read()
+
+        assert len(rows) == 1
+        assert rows[0]["name"] == "alice"
+
+    def test_read_table_arg_overrides_model(self, dbt_project: Path, dbt_database: Path) -> None:
+        with (
+            patch("dataenginex.data.connectors.dbt._DBT_AVAILABLE", True),
+            patch("subprocess.run", side_effect=_ok_run) as mock_sub,
+        ):
+            c = DbtConnector(project_dir=str(dbt_project), model="default_model")
+            c.read(table="users_cleaned")
+
+        cmd = mock_sub.call_args[0][0]
+        assert "users_cleaned" in cmd
+
+    def test_read_dbt_failure_raises(self, dbt_project: Path) -> None:
+        with (
+            patch("dataenginex.data.connectors.dbt._DBT_AVAILABLE", True),
+            patch("subprocess.run", side_effect=_fail_run),
+        ):
+            c = DbtConnector(project_dir=str(dbt_project), model="m")
+            with pytest.raises(RuntimeError, match="dbt run failed"):
+                c.read()
+
+    def test_read_missing_database_returns_default(self, dbt_project: Path) -> None:
+        with (
+            patch("dataenginex.data.connectors.dbt._DBT_AVAILABLE", True),
+            patch("subprocess.run", side_effect=_ok_run),
+        ):
+            c = DbtConnector(project_dir=str(dbt_project), model="m")
+            rows = c.read(default=[])
+
+        assert rows == []
+
+    def test_read_missing_database_raises_without_default(self, dbt_project: Path) -> None:
+        with (
+            patch("dataenginex.data.connectors.dbt._DBT_AVAILABLE", True),
+            patch("subprocess.run", side_effect=_ok_run),
+        ):
+            c = DbtConnector(project_dir=str(dbt_project), model="m")
+            with pytest.raises(FileNotFoundError, match="dbt target database not found"):
+                c.read()
+
+    def test_read_missing_model_in_db_returns_default(
+        self, dbt_project: Path, dbt_database: Path
+    ) -> None:
+        with (
+            patch("dataenginex.data.connectors.dbt._DBT_AVAILABLE", True),
+            patch("subprocess.run", side_effect=_ok_run),
+        ):
+            c = DbtConnector(project_dir=str(dbt_project), model="nonexistent_model")
+            rows = c.read(default=[])
+
+        assert rows == []
+
+    def test_read_custom_target_database(self, dbt_project: Path, tmp_path: Path) -> None:
+        custom_db = tmp_path / "custom.duckdb"
+        conn = duckdb.connect(str(custom_db))
+        conn.execute("CREATE TABLE orders AS SELECT 99 AS order_id")
+        conn.close()
+
+        with (
+            patch("dataenginex.data.connectors.dbt._DBT_AVAILABLE", True),
+            patch("subprocess.run", side_effect=_ok_run),
+        ):
+            c = DbtConnector(
+                project_dir=str(dbt_project),
+                model="orders",
+                target_database=str(custom_db),
+            )
+            rows = c.read()
+
+        assert rows[0]["order_id"] == 99
+
+
+class TestDbtConnectorWrite:
+    def test_write_raises_not_implemented(self, dbt_project: Path) -> None:
+        with patch("dataenginex.data.connectors.dbt._DBT_AVAILABLE", True):
+            c = DbtConnector(project_dir=str(dbt_project), model="m")
+            with pytest.raises(NotImplementedError, match="read-only"):
+                c.write([{"x": 1}])

--- a/tests/unit/test_duckdb_connector.py
+++ b/tests/unit/test_duckdb_connector.py
@@ -37,3 +37,31 @@ class TestDuckDBConnector(ConnectorConformanceTests):
         conn.connect()
         conn.write([], table="empty")
         conn.disconnect()
+
+    def test_write_overwrites_existing_table(self, tmp_path) -> None:
+        conn = DuckDBConnector(database=str(tmp_path / "test.duckdb"))
+        conn.connect()
+        conn.write([{"x": 1}], table="t")
+        conn.write([{"x": 2}, {"x": 3}], table="t")
+        rows = conn.read(table="t")
+        assert len(rows) == 2, "second write must overwrite, not be silently dropped"
+        assert {r["x"] for r in rows} == {2, 3}
+        conn.disconnect()
+
+    def test_write_pyarrow_table(self, tmp_path) -> None:
+        import pyarrow as pa
+
+        conn = DuckDBConnector(database=str(tmp_path / "test.duckdb"))
+        conn.connect()
+        tbl = pa.Table.from_pylist([{"y": 10}, {"y": 20}])
+        conn.write(tbl, table="arrow_t")
+        rows = conn.read(table="arrow_t")
+        assert [r["y"] for r in rows] == [10, 20]
+        conn.disconnect()
+
+    def test_write_unsupported_type_raises(self, tmp_path) -> None:
+        conn = DuckDBConnector(database=str(tmp_path / "test.duckdb"))
+        conn.connect()
+        with pytest.raises(TypeError, match="Unsupported data type"):
+            conn.write("not a list", table="t")
+        conn.disconnect()

--- a/tests/unit/test_guarded_provider.py
+++ b/tests/unit/test_guarded_provider.py
@@ -1,0 +1,108 @@
+"""Tests for ai/routing/guarded.py — GuardedProvider."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from dataenginex.ai.routing.guarded import GuardedProvider
+from dataenginex.ai.routing.router import BaseProvider
+from dataenginex.secops.guard import PrivacyBlocked, PrivacyGuard, PrivacyGuardConfig
+
+
+def _mock_provider(response: str = "ok") -> BaseProvider:
+    p = MagicMock(spec=BaseProvider)
+    p.generate.return_value = response
+    return p
+
+
+def _guard(block: bool = False) -> PrivacyGuard:
+    cfg = PrivacyGuardConfig(enabled=True, block_on_detect=block)
+    return PrivacyGuard(config=cfg)
+
+
+class TestGuardedProviderInit:
+    def test_inner_accessible(self) -> None:
+        inner = _mock_provider()
+        gp = GuardedProvider(inner, _guard(), target="openai")
+        assert gp.inner is inner
+
+    def test_target_stored(self) -> None:
+        gp = GuardedProvider(_mock_provider(), _guard(), target="anthropic")
+        assert gp.target == "anthropic"
+
+    def test_target_derived_from_class(self) -> None:
+        class MyCustomProvider(BaseProvider):
+            def generate(self, prompt: str, **kw: object) -> str:
+                return ""
+
+        gp = GuardedProvider(MyCustomProvider(), _guard())
+        assert gp.target == "mycustom"
+
+    def test_derive_target_strips_provider_suffix(self) -> None:
+        class OpenAIProvider(BaseProvider):
+            def generate(self, prompt: str, **kw: object) -> str:
+                return ""
+
+        gp = GuardedProvider(OpenAIProvider(), _guard())
+        assert gp.target == "openai"
+
+
+class TestGuardedProviderGenerate:
+    def test_passes_prompt_through(self) -> None:
+        inner = _mock_provider("hello")
+        gp = GuardedProvider(inner, _guard(), target="local")
+        result = gp.generate("safe prompt")
+        assert result == "hello"
+        inner.generate.assert_called_once()
+
+    def test_clean_prompt_reaches_inner(self) -> None:
+        inner = _mock_provider()
+        gp = GuardedProvider(inner, _guard(), target="ollama")
+        gp.generate("no sensitive data here")
+        assert inner.generate.called
+
+    def test_blocked_prompt_raises_privacy_blocked(self) -> None:
+        inner = _mock_provider()
+        guard = PrivacyGuard(config=PrivacyGuardConfig(enabled=True, block_on_detect=True))
+        gp = GuardedProvider(inner, guard, target="openai")
+        with pytest.raises(PrivacyBlocked):
+            gp.generate("my SSN is 123-45-6789 and email is alice@example.com")
+        inner.generate.assert_not_called()
+
+    def test_kwargs_forwarded_to_inner(self) -> None:
+        inner = _mock_provider("response")
+        gp = GuardedProvider(inner, _guard(), target="local")
+        gp.generate("prompt", temperature=0.5, max_tokens=100)
+        inner.generate.assert_called_once()
+        _, kw = inner.generate.call_args
+        assert "temperature" in kw
+        assert "max_tokens" in kw
+
+    def test_local_target_bypasses_scan(self) -> None:
+        inner = _mock_provider("local ok")
+        cfg = PrivacyGuardConfig(enabled=True, allow_local=True, block_on_detect=True)
+        guard = PrivacyGuard(config=cfg)
+        gp = GuardedProvider(inner, guard, target="ollama")
+        # Even with PII — local target is bypassed
+        result = gp.generate("email: alice@example.com")
+        assert result == "local ok"
+
+
+class TestDeriveTarget:
+    def test_fallback_is_nonempty_string(self) -> None:
+        class Provider(BaseProvider):
+            def generate(self, p: str, **k: object) -> str:
+                return ""
+
+        result = GuardedProvider._derive_target(Provider())
+        assert isinstance(result, str) and len(result) > 0
+
+    def test_strips_provider_suffix(self) -> None:
+        class AnthropicProvider(BaseProvider):
+            def generate(self, p: str, **k: object) -> str:
+                return ""
+
+        result = GuardedProvider._derive_target(AnthropicProvider())
+        assert result == "anthropic"

--- a/tests/unit/test_llm_extended.py
+++ b/tests/unit/test_llm_extended.py
@@ -1,0 +1,182 @@
+"""Extended tests for dataenginex.ai.llm — providers, config, and factory."""
+
+from __future__ import annotations
+
+import pytest
+
+from dataenginex.ai.llm import (
+    ChatMessage,
+    LLMConfig,
+    LLMProvider,
+    LLMResponse,
+    MockProvider,
+    OllamaProvider,
+    VLLMProvider,
+    get_llm_provider,
+)
+
+# ── Data models ───────────────────────────────────────────────────────────────
+
+
+class TestChatMessage:
+    def test_fields(self) -> None:
+        m = ChatMessage(role="user", content="hello")
+        assert m.role == "user"
+        assert m.content == "hello"
+
+    def test_system_role(self) -> None:
+        m = ChatMessage(role="system", content="You are a helpful assistant.")
+        assert m.role == "system"
+
+    def test_assistant_role(self) -> None:
+        m = ChatMessage(role="assistant", content="I can help.")
+        assert m.role == "assistant"
+
+
+class TestLLMConfig:
+    def test_defaults(self) -> None:
+        c = LLMConfig()
+        assert c.model is not None
+        assert c.max_tokens > 0
+
+    def test_custom_values(self) -> None:
+        c = LLMConfig(model="llama3:8b", max_tokens=256)
+        assert c.model == "llama3:8b"
+        assert c.max_tokens == 256
+
+
+class TestLLMResponse:
+    def test_fields(self) -> None:
+        r = LLMResponse(text="hello")
+        assert r.text == "hello"
+
+    def test_optional_metadata(self) -> None:
+        r = LLMResponse(text="hi", model="llama3", total_tokens=42)
+        assert r.model == "llama3"
+        assert r.total_tokens == 42
+
+    def test_default_empty_text(self) -> None:
+        r = LLMResponse(text="")
+        assert r.text == ""
+
+
+# ── LLMProvider ABC ───────────────────────────────────────────────────────────
+
+
+class TestLLMProviderABC:
+    def test_cannot_instantiate(self) -> None:
+        with pytest.raises(TypeError):
+            LLMProvider()  # type: ignore[abstract]
+
+    def test_generate_with_context(self) -> None:
+        p = MockProvider(default_response="ctx response")
+        result = p.generate_with_context("question", "some context")
+        assert isinstance(result, LLMResponse)
+        assert result.text.startswith("ctx response")
+
+    def test_generate_with_context_custom_system_prompt(self) -> None:
+        p = MockProvider()
+        result = p.generate_with_context("q", "ctx", system_prompt="You are helpful.")
+        assert isinstance(result, LLMResponse)
+
+
+# ── MockProvider ──────────────────────────────────────────────────────────────
+
+
+class TestMockProviderExtended:
+    def test_default_response_prefix(self) -> None:
+        p = MockProvider(default_response="fixed")
+        r = p.generate("any prompt")
+        assert r.text.startswith("fixed")  # appends metadata suffix
+
+    def test_response_is_llm_response(self) -> None:
+        p = MockProvider()
+        r = p.generate("hello")
+        assert isinstance(r, LLMResponse)
+
+    def test_call_history_tracked(self) -> None:
+        p = MockProvider()
+        p.generate("first")
+        p.generate("second")
+        assert len(p.call_history) == 2
+
+    def test_is_available(self) -> None:
+        assert MockProvider().is_available() is True
+
+    def test_chat_returns_response(self) -> None:
+        p = MockProvider(default_response="chat reply")
+        msgs = [ChatMessage(role="user", content="hi")]
+        r = p.chat(msgs)
+        assert r.text.startswith("chat reply")
+
+    def test_chat_history_tracked(self) -> None:
+        p = MockProvider()
+        p.chat([ChatMessage(role="user", content="hello")])
+        p.chat([ChatMessage(role="user", content="bye")])
+        assert len(p.call_history) == 2
+
+    def test_tokens_usage_populated(self) -> None:
+        p = MockProvider()
+        r = p.generate("test prompt")
+        assert r.total_tokens is not None and r.total_tokens > 0
+
+    def test_model_in_response(self) -> None:
+        p = MockProvider()
+        r = p.generate("test")
+        assert r.model is not None
+
+
+# ── OllamaProvider (no server needed — just init tests) ──────────────────────
+
+
+class TestOllamaProviderInit:
+    def test_init_defaults(self) -> None:
+        p = OllamaProvider()
+        assert p is not None
+
+    def test_init_custom_base_url(self) -> None:
+        p = OllamaProvider(base_url="http://my-server:11434")
+        assert "my-server" in p.base_url
+
+    def test_is_available_false_without_server(self) -> None:
+        p = OllamaProvider(base_url="http://127.0.0.1:19999")
+        assert p.is_available() is False
+
+
+# ── VLLMProvider ──────────────────────────────────────────────────────────────
+
+
+class TestVLLMProvider:
+    def test_init(self) -> None:
+        p = VLLMProvider(model="mistral-7b")
+        assert p is not None
+
+    def test_is_openai_compatible_subclass(self) -> None:
+        from dataenginex.ai.llm import OpenAICompatibleProvider
+
+        assert isinstance(VLLMProvider(), OpenAICompatibleProvider)
+
+
+# ── get_llm_provider factory ──────────────────────────────────────────────────
+
+
+class TestGetLLMProviderExtended:
+    def test_mock_provider(self) -> None:
+        p = get_llm_provider("mock")
+        assert isinstance(p, MockProvider)
+
+    def test_ollama_provider(self) -> None:
+        p = get_llm_provider("ollama")
+        assert isinstance(p, OllamaProvider)
+
+    def test_unknown_raises(self) -> None:
+        with pytest.raises((ValueError, KeyError)):
+            get_llm_provider("nonexistent_llm_xyz")
+
+    def test_case_insensitive(self) -> None:
+        p = get_llm_provider("MOCK")
+        assert isinstance(p, MockProvider)
+
+    def test_vllm_provider(self) -> None:
+        p = get_llm_provider("vllm", model="test-model")
+        assert isinstance(p, VLLMProvider)

--- a/tests/unit/test_medallion_extended.py
+++ b/tests/unit/test_medallion_extended.py
@@ -1,0 +1,261 @@
+"""Extended tests for core/medallion_architecture.py — storage backends and data lineage."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from dataenginex.core.medallion_architecture import (
+    DataLayer,
+    DataLineage,
+    LayerConfiguration,
+    LocalParquetStorage,
+    MedallionArchitecture,
+    StorageBackend,
+    StorageFormat,
+)
+
+# ── StorageFormat ─────────────────────────────────────────────────────────────
+
+
+class TestStorageFormat:
+    def test_values(self) -> None:
+        assert StorageFormat.PARQUET == "parquet"
+        assert StorageFormat.DELTA == "delta"
+        assert StorageFormat.ICEBERG == "iceberg"
+        assert StorageFormat.BIGQUERY == "bigquery"
+
+
+# ── DataLayer ─────────────────────────────────────────────────────────────────
+
+
+class TestDataLayerExtended:
+    def test_all_layers(self) -> None:
+        assert {DataLayer.BRONZE, DataLayer.SILVER, DataLayer.GOLD} == {"bronze", "silver", "gold"}
+
+
+# ── LayerConfiguration ────────────────────────────────────────────────────────
+
+
+class TestLayerConfiguration:
+    def _make(self, threshold: float = 0.5) -> LayerConfiguration:
+        return LayerConfiguration(
+            layer_name="bronze",
+            description="raw",
+            purpose="preserve",
+            storage_format=StorageFormat.PARQUET,
+            local_path="data/bronze",
+            bigquery_dataset="bronze",
+            retention_days=90,
+            schema_validation=False,
+            quality_threshold=threshold,
+        )
+
+    def test_valid_creation(self) -> None:
+        lc = self._make()
+        assert lc.layer_name == "bronze"
+        assert lc.compression == "snappy"
+
+    def test_threshold_zero(self) -> None:
+        lc = self._make(0.0)
+        assert lc.quality_threshold == 0.0
+
+    def test_threshold_one(self) -> None:
+        lc = self._make(1.0)
+        assert lc.quality_threshold == 1.0
+
+    def test_invalid_threshold_negative(self) -> None:
+        with pytest.raises(ValueError):
+            self._make(-0.1)
+
+    def test_invalid_threshold_above_one(self) -> None:
+        with pytest.raises(ValueError):
+            self._make(1.1)
+
+    def test_none_retention(self) -> None:
+        lc = LayerConfiguration(
+            layer_name="gold",
+            description="",
+            purpose="",
+            storage_format=StorageFormat.PARQUET,
+            local_path="data/gold",
+            bigquery_dataset="gold",
+            retention_days=None,
+            schema_validation=True,
+            quality_threshold=0.9,
+        )
+        assert lc.retention_days is None
+
+
+# ── MedallionArchitecture ─────────────────────────────────────────────────────
+
+
+class TestMedallionArchitectureExtended:
+    def test_get_bronze_config(self) -> None:
+        c = MedallionArchitecture.get_layer_config(DataLayer.BRONZE)
+        assert c is not None
+        assert c.quality_threshold == 0.0
+
+    def test_get_silver_config(self) -> None:
+        c = MedallionArchitecture.get_layer_config(DataLayer.SILVER)
+        assert c is not None
+        assert c.quality_threshold == 0.75
+
+    def test_get_gold_config(self) -> None:
+        c = MedallionArchitecture.get_layer_config(DataLayer.GOLD)
+        assert c is not None
+        assert c.quality_threshold == 0.90
+
+    def test_get_all_layers(self) -> None:
+        layers = MedallionArchitecture.get_all_layers()
+        assert len(layers) == 3
+        names = [lyr.layer_name for lyr in layers]
+        assert "bronze" in names and "silver" in names and "gold" in names
+
+
+# ── StorageBackend (ABC) ──────────────────────────────────────────────────────
+
+
+class TestStorageBackendABC:
+    def test_cannot_instantiate(self) -> None:
+        with pytest.raises(TypeError):
+            StorageBackend()  # type: ignore[abstract]
+
+    def test_concrete_subclass(self) -> None:
+        class MinimalBackend(StorageBackend):
+            def write(self, data, path, format):
+                return True
+
+            def read(self, path, format):
+                return None
+
+            def delete(self, path):
+                return True
+
+            def list_objects(self, prefix=""):
+                return []
+
+            def exists(self, path):
+                return False
+
+        b = MinimalBackend()
+        assert b.write(None, "x", StorageFormat.PARQUET) is True
+        assert b.read("x", StorageFormat.PARQUET) is None
+        assert b.delete("x") is True
+        assert b.list_objects() == []
+        assert b.exists("x") is False
+
+
+# ── LocalParquetStorage ───────────────────────────────────────────────────────
+
+
+class TestLocalParquetStorage:
+    def test_init(self, tmp_path: Path) -> None:
+        s = LocalParquetStorage(base_path=str(tmp_path))
+        assert s.base_path == str(tmp_path)
+
+    def test_write_and_exists(self, tmp_path: Path) -> None:
+        s = LocalParquetStorage(base_path=str(tmp_path))
+        data = [{"id": 1, "name": "alice"}, {"id": 2, "name": "bob"}]
+        result = s.write(data, "test_table", StorageFormat.PARQUET)
+        assert result is True
+        assert s.exists("test_table")
+
+    def test_read_after_write(self, tmp_path: Path) -> None:
+        s = LocalParquetStorage(base_path=str(tmp_path))
+        data = [{"x": 10}]
+        s.write(data, "mytable", StorageFormat.PARQUET)
+        records = s.read("mytable", StorageFormat.PARQUET)
+        assert records is not None
+        assert len(records) == 1
+
+    def test_read_missing_returns_none(self, tmp_path: Path) -> None:
+        s = LocalParquetStorage(base_path=str(tmp_path))
+        result = s.read("nonexistent", StorageFormat.PARQUET)
+        assert result is None
+
+    def test_list_objects(self, tmp_path: Path) -> None:
+        s = LocalParquetStorage(base_path=str(tmp_path))
+        s.write([{"v": 1}], "table_a", StorageFormat.PARQUET)
+        s.write([{"v": 2}], "table_b", StorageFormat.PARQUET)
+        objects = s.list_objects()
+        assert len(objects) == 2
+
+    def test_list_objects_with_prefix(self, tmp_path: Path) -> None:
+        s = LocalParquetStorage(base_path=str(tmp_path))
+        s.write([{"v": 1}], "abc_table", StorageFormat.PARQUET)
+        s.write([{"v": 2}], "xyz_table", StorageFormat.PARQUET)
+        objects = s.list_objects(prefix="abc")
+        assert all("abc" in o for o in objects)
+
+    def test_list_objects_empty(self, tmp_path: Path) -> None:
+        s = LocalParquetStorage(base_path=str(tmp_path))
+        assert s.list_objects() == []
+
+    def test_delete_existing(self, tmp_path: Path) -> None:
+        s = LocalParquetStorage(base_path=str(tmp_path))
+        s.write([{"v": 1}], "del_table", StorageFormat.PARQUET)
+        result = s.delete("del_table")
+        assert result is True
+        assert not s.exists("del_table")
+
+    def test_delete_missing_returns_false(self, tmp_path: Path) -> None:
+        s = LocalParquetStorage(base_path=str(tmp_path))
+        result = s.delete("ghost")
+        assert result is False
+
+    def test_exists_false_when_missing(self, tmp_path: Path) -> None:
+        s = LocalParquetStorage(base_path=str(tmp_path))
+        assert s.exists("missing") is False
+
+
+# ── DataLineage ───────────────────────────────────────────────────────────────
+
+
+class TestDataLineage:
+    def test_init_empty(self) -> None:
+        dl = DataLineage()
+        assert dl.lineage == {}
+
+    def test_record_bronze_ingestion(self) -> None:
+        dl = DataLineage()
+        lid = dl.record_bronze_ingestion("s3://bucket/file.csv", 1000, "2026-01-01")
+        assert lid.startswith("bronze_")
+        event = dl.get_lineage(lid)
+        assert event is not None
+        assert event["layer"] == "bronze"
+        assert event["record_count"] == 1000
+
+    def test_record_silver_transformation(self) -> None:
+        dl = DataLineage()
+        bronze_id = dl.record_bronze_ingestion("src", 100, "2026-01-01")
+        silver_id = dl.record_silver_transformation(bronze_id, 95, 0.88)
+        assert silver_id == f"{bronze_id}_silver"
+        event = dl.get_lineage(silver_id)
+        assert event["layer"] == "silver"
+        assert event["parent"] == bronze_id
+        assert pytest.approx(event["quality_score"]) == 0.88
+
+    def test_record_gold_enrichment(self) -> None:
+        dl = DataLineage()
+        bronze_id = dl.record_bronze_ingestion("src", 100, "2026-01-01")
+        silver_id = dl.record_silver_transformation(bronze_id, 95, 0.88)
+        gold_id = dl.record_gold_enrichment(silver_id, 90, "all-MiniLM")
+        assert gold_id == f"{silver_id}_gold"
+        event = dl.get_lineage(gold_id)
+        assert event["layer"] == "gold"
+        assert event["embedding_model"] == "all-MiniLM"
+
+    def test_get_lineage_missing_returns_none(self) -> None:
+        dl = DataLineage()
+        assert dl.get_lineage("ghost") is None
+
+    def test_full_medallion_chain(self) -> None:
+        dl = DataLineage()
+        bid = dl.record_bronze_ingestion("kafka-topic", 5000, "2026-06-01")
+        sid = dl.record_silver_transformation(bid, 4800, 0.92)
+        gid = dl.record_gold_enrichment(sid, 4800, "text-embedding-ada-002")
+        assert dl.get_lineage(bid)["status"] == "raw"
+        assert dl.get_lineage(sid)["status"] == "cleaned"
+        assert dl.get_lineage(gid)["status"] == "enriched"

--- a/tests/unit/test_middleware_metrics.py
+++ b/tests/unit/test_middleware_metrics.py
@@ -1,0 +1,101 @@
+"""Tests for dataenginex.middleware.domain_metrics — Prometheus metric objects."""
+
+from __future__ import annotations
+
+from dataenginex.middleware.domain_metrics import (
+    ai_agent_iterations,
+    ai_tokens_total,
+    ai_tool_calls_total,
+    ml_drift_score,
+    ml_model_predictions_total,
+    pipeline_run_duration_seconds,
+    pipeline_runs_total,
+    quality_gate_evaluations_total,
+    tenant_operations_total,
+)
+
+
+class TestDomainMetricsImport:
+    """Verify all declared metrics are importable and have the expected Prometheus type."""
+
+    def test_pipeline_runs_total_is_counter(self) -> None:
+        from prometheus_client import Counter
+
+        assert isinstance(pipeline_runs_total, Counter)
+
+    def test_pipeline_run_duration_is_histogram(self) -> None:
+        from prometheus_client import Histogram
+
+        assert isinstance(pipeline_run_duration_seconds, Histogram)
+
+    def test_quality_gate_is_counter(self) -> None:
+        from prometheus_client import Counter
+
+        assert isinstance(quality_gate_evaluations_total, Counter)
+
+    def test_ai_tokens_total_is_counter(self) -> None:
+        from prometheus_client import Counter
+
+        assert isinstance(ai_tokens_total, Counter)
+
+    def test_ai_tool_calls_is_counter(self) -> None:
+        from prometheus_client import Counter
+
+        assert isinstance(ai_tool_calls_total, Counter)
+
+    def test_ai_agent_iterations_is_histogram(self) -> None:
+        from prometheus_client import Histogram
+
+        assert isinstance(ai_agent_iterations, Histogram)
+
+    def test_ml_drift_score_is_gauge(self) -> None:
+        from prometheus_client import Gauge
+
+        assert isinstance(ml_drift_score, Gauge)
+
+    def test_ml_predictions_is_counter(self) -> None:
+        from prometheus_client import Counter
+
+        assert isinstance(ml_model_predictions_total, Counter)
+
+    def test_tenant_operations_is_counter(self) -> None:
+        from prometheus_client import Counter
+
+        assert isinstance(tenant_operations_total, Counter)
+
+
+class TestDomainMetricsUsage:
+    """Basic usage — label sets and observe calls must not raise."""
+
+    def test_pipeline_runs_increment(self) -> None:
+        pipeline_runs_total.labels(pipeline="test_pipe", status="success").inc()
+
+    def test_pipeline_duration_observe(self) -> None:
+        pipeline_run_duration_seconds.labels(pipeline="test_pipe").observe(1.23)
+
+    def test_quality_gate_increment(self) -> None:
+        quality_gate_evaluations_total.labels(
+            pipeline="ingest", gate="completeness", result="pass"
+        ).inc()
+
+    def test_ai_tokens_increment(self) -> None:
+        ai_tokens_total.labels(provider="ollama", model="llama3", direction="input").inc(100)
+
+    def test_ai_tool_calls_increment(self) -> None:
+        ai_tool_calls_total.labels(tool="query", status="ok").inc()
+
+    def test_ai_agent_iterations_observe(self) -> None:
+        ai_agent_iterations.labels(agent="assistant").observe(3)
+
+    def test_ml_drift_score_set(self) -> None:
+        ml_drift_score.labels(pipeline="churn", feature="spend", method="psi").set(0.12)
+
+    def test_ml_predictions_increment(self) -> None:
+        ml_model_predictions_total.labels(
+            model="churn_model", version="1.0", status="success"
+        ).inc()
+
+    def test_tenant_operations_increment(self) -> None:
+        tenant_operations_total.labels(
+            tenant="default", operation="pipeline_run", status="ok"
+        ).inc()

--- a/tests/unit/test_parquet_connector.py
+++ b/tests/unit/test_parquet_connector.py
@@ -1,0 +1,173 @@
+"""Tests for dataenginex.data.connectors.parquet — ParquetConnector."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from dataenginex.data.connectors.parquet import ParquetConnector
+
+
+@pytest.fixture()
+def parquet_file(tmp_path: Path) -> Path:
+    """Write a tiny parquet file and return its path."""
+    import pyarrow as pa
+    import pyarrow.parquet as pq
+
+    tbl = pa.table({"id": [1, 2, 3], "name": ["alice", "bob", "carol"]})
+    p = tmp_path / "test.parquet"
+    pq.write_table(tbl, p)
+    return p
+
+
+@pytest.fixture()
+def parquet_dir(tmp_path: Path, parquet_file: Path) -> Path:
+    """Return a directory containing one parquet file."""
+    import shutil
+
+    d = tmp_path / "parquet_dir"
+    d.mkdir()
+    shutil.copy(parquet_file, d / "data.parquet")
+    return d
+
+
+class TestParquetConnectorConnect:
+    def test_connect_creates_connection(self, parquet_file: Path) -> None:
+        c = ParquetConnector(path=str(parquet_file))
+        c.connect()
+        assert c._conn is not None
+        c.disconnect()
+
+    def test_disconnect_clears_connection(self, parquet_file: Path) -> None:
+        c = ParquetConnector(path=str(parquet_file))
+        c.connect()
+        c.disconnect()
+        assert c._conn is None
+
+    def test_disconnect_idempotent(self, parquet_file: Path) -> None:
+        c = ParquetConnector(path=str(parquet_file))
+        c.connect()
+        c.disconnect()
+        c.disconnect()  # should not raise
+
+    def test_health_check_connected(self, parquet_file: Path) -> None:
+        c = ParquetConnector(path=str(parquet_file))
+        c.connect()
+        assert c.health_check() is True
+        c.disconnect()
+
+    def test_health_check_disconnected(self, parquet_file: Path) -> None:
+        c = ParquetConnector(path=str(parquet_file))
+        assert c.health_check() is False
+
+
+class TestParquetConnectorRead:
+    def test_read_file(self, parquet_file: Path) -> None:
+        c = ParquetConnector(path=str(parquet_file))
+        c.connect()
+        rows = c.read()
+        assert len(rows) == 3
+        assert rows[0]["name"] == "alice"
+        c.disconnect()
+
+    def test_read_not_connected_raises(self, parquet_file: Path) -> None:
+        c = ParquetConnector(path=str(parquet_file))
+        with pytest.raises(RuntimeError, match="Not connected"):
+            c.read()
+
+    def test_read_directory_by_table(self, parquet_dir: Path) -> None:
+        c = ParquetConnector(path=str(parquet_dir))
+        c.connect()
+        rows = c.read(table="data")
+        assert len(rows) == 3
+        c.disconnect()
+
+    def test_read_directory_by_table_with_ext(self, parquet_dir: Path) -> None:
+        c = ParquetConnector(path=str(parquet_dir))
+        c.connect()
+        rows = c.read(table="data.parquet")
+        assert len(rows) == 3
+        c.disconnect()
+
+    def test_read_missing_file_with_default(self, parquet_dir: Path) -> None:
+        c = ParquetConnector(path=str(parquet_dir))
+        c.connect()
+        rows = c.read(table="nonexistent", default=[])
+        assert rows == []
+        c.disconnect()
+
+    def test_read_missing_file_raises_without_default(self, parquet_dir: Path) -> None:
+        c = ParquetConnector(path=str(parquet_dir))
+        c.connect()
+        with pytest.raises(FileNotFoundError):
+            c.read(table="nonexistent")
+        c.disconnect()
+
+    def test_read_directory_no_table_raises(self, parquet_dir: Path) -> None:
+        c = ParquetConnector(path=str(parquet_dir))
+        c.connect()
+        with pytest.raises(ValueError, match="No table"):
+            c.read()
+        c.disconnect()
+
+    def test_read_with_default_file(self, parquet_dir: Path) -> None:
+        c = ParquetConnector(path=str(parquet_dir), default_file="data.parquet")
+        c.connect()
+        rows = c.read()
+        assert len(rows) == 3
+        c.disconnect()
+
+
+class TestParquetConnectorWrite:
+    def test_write_list_creates_file(self, tmp_path: Path) -> None:
+        out = tmp_path / "output.parquet"
+        c = ParquetConnector(path=str(out))
+        c.connect()
+        c.write([{"x": 1}, {"x": 2}])
+        assert out.exists()
+        c.disconnect()
+
+    def test_write_not_connected_raises(self, tmp_path: Path) -> None:
+        c = ParquetConnector(path=str(tmp_path / "out.parquet"))
+        with pytest.raises(RuntimeError, match="Not connected"):
+            c.write([{"x": 1}])
+
+    def test_write_pyarrow_table(self, tmp_path: Path) -> None:
+        import pyarrow as pa
+
+        out = tmp_path / "arrow.parquet"
+        c = ParquetConnector(path=str(out))
+        c.connect()
+        tbl = pa.table({"a": [1, 2]})
+        c.write(tbl)
+        assert out.exists()
+        c.disconnect()
+
+    def test_write_unsupported_type_raises(self, tmp_path: Path) -> None:
+        out = tmp_path / "bad.parquet"
+        c = ParquetConnector(path=str(out))
+        c.connect()
+        with pytest.raises(TypeError):
+            c.write("not a list or table")
+        c.disconnect()
+
+    def test_write_to_dir_uses_table_name(self, tmp_path: Path) -> None:
+        d = tmp_path / "parquet_out"
+        d.mkdir()
+        c = ParquetConnector(path=str(d))
+        c.connect()
+        c.write([{"v": 42}], table="mydata.parquet")
+        assert (d / "mydata.parquet").exists()
+        c.disconnect()
+
+    def test_write_then_read_roundtrip(self, tmp_path: Path) -> None:
+        out = tmp_path / "roundtrip.parquet"
+        c = ParquetConnector(path=str(out))
+        c.connect()
+        data = [{"id": 1, "val": "hello"}, {"id": 2, "val": "world"}]
+        c.write(data)
+        rows = c.read()
+        assert len(rows) == 2
+        assert rows[0]["val"] == "hello"
+        c.disconnect()

--- a/tests/unit/test_privacy_guard_wiring.py
+++ b/tests/unit/test_privacy_guard_wiring.py
@@ -1,0 +1,245 @@
+"""Tests for PrivacyGuard wiring: dex.yaml schema + engine integration."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from dataenginex.config.schema import (
+    DexConfig,
+    GuardConfig,
+    ProjectConfig,
+    SecopsConfig,
+)
+from dataenginex.secops import (
+    MaskingStrategy,
+    PIIType,
+    PrivacyGuardConfig,
+)
+
+# ---------------------------------------------------------------------------
+# GuardConfig — Pydantic schema
+# ---------------------------------------------------------------------------
+
+
+class TestGuardConfigSchema:
+    def test_defaults(self) -> None:
+        cfg = GuardConfig()
+        assert cfg.enabled is True
+        assert cfg.allow_local is True
+        assert cfg.block_on_detect is False
+        assert cfg.log_all_outbound is True
+        assert cfg.strategies == {}
+        assert "ollama" in cfg.local_targets
+
+    def test_round_trip_via_dict(self) -> None:
+        raw = {
+            "enabled": True,
+            "allow_local": False,
+            "block_on_detect": True,
+            "log_all_outbound": True,
+            "strategies": {"email": "hash", "ssn": "redact"},
+            "local_targets": ["my_self_hosted"],
+        }
+        cfg = GuardConfig(**raw)
+        assert cfg.allow_local is False
+        assert cfg.block_on_detect is True
+        assert cfg.strategies == {"email": "hash", "ssn": "redact"}
+        assert cfg.local_targets == ["my_self_hosted"]
+
+    def test_secops_config_includes_guard_block(self) -> None:
+        secops = SecopsConfig()
+        assert hasattr(secops, "guard")
+        assert isinstance(secops.guard, GuardConfig)
+
+    def test_dex_config_secops_guard_default(self) -> None:
+        cfg = DexConfig(project=ProjectConfig(name="test"))
+        assert cfg.secops.guard.enabled is True
+
+    def test_dex_config_secops_guard_overrides_load(self) -> None:
+        cfg = DexConfig(
+            project=ProjectConfig(name="test"),
+            secops=SecopsConfig(
+                guard=GuardConfig(
+                    enabled=False,
+                    strategies={"phone": "partial"},
+                ),
+            ),
+        )
+        assert cfg.secops.guard.enabled is False
+        assert cfg.secops.guard.strategies == {"phone": "partial"}
+
+
+# ---------------------------------------------------------------------------
+# PrivacyGuardConfig.from_dict — loose dict → typed dataclass
+# ---------------------------------------------------------------------------
+
+
+class TestPrivacyGuardConfigFromDict:
+    def test_empty_dict_gives_defaults(self) -> None:
+        cfg = PrivacyGuardConfig.from_dict({})
+        assert cfg.enabled is True
+        assert cfg.allow_local is True
+        assert cfg.block_on_detect is False
+        assert cfg.strategies == {}
+        assert "ollama" in cfg.local_targets
+
+    def test_string_strategies_converted_to_enums(self) -> None:
+        cfg = PrivacyGuardConfig.from_dict(
+            {
+                "strategies": {"email": "hash", "ssn": "redact", "phone": "partial"},
+            }
+        )
+        assert cfg.strategies[PIIType.EMAIL] == MaskingStrategy.HASH
+        assert cfg.strategies[PIIType.SSN] == MaskingStrategy.REDACT
+        assert cfg.strategies[PIIType.PHONE] == MaskingStrategy.PARTIAL
+
+    def test_unknown_pii_type_raises(self) -> None:
+        with pytest.raises(ValueError):
+            PrivacyGuardConfig.from_dict({"strategies": {"not_a_pii_type": "hash"}})
+
+    def test_unknown_masking_strategy_raises(self) -> None:
+        with pytest.raises(ValueError):
+            PrivacyGuardConfig.from_dict({"strategies": {"email": "obfuscate_lol"}})
+
+    def test_local_targets_list_becomes_frozenset(self) -> None:
+        cfg = PrivacyGuardConfig.from_dict({"local_targets": ["a", "b", "c"]})
+        assert cfg.local_targets == frozenset({"a", "b", "c"})
+
+    def test_local_targets_none_uses_default(self) -> None:
+        cfg = PrivacyGuardConfig.from_dict({"local_targets": None})
+        assert "ollama" in cfg.local_targets
+
+    def test_all_flags_round_trip(self) -> None:
+        raw = {
+            "enabled": False,
+            "allow_local": False,
+            "block_on_detect": True,
+            "log_all_outbound": False,
+            "strategies": {"email": "hash"},
+            "local_targets": ["x"],
+        }
+        cfg = PrivacyGuardConfig.from_dict(raw)
+        assert cfg.enabled is False
+        assert cfg.allow_local is False
+        assert cfg.block_on_detect is True
+        assert cfg.log_all_outbound is False
+        assert cfg.strategies == {PIIType.EMAIL: MaskingStrategy.HASH}
+        assert cfg.local_targets == frozenset({"x"})
+
+
+# ---------------------------------------------------------------------------
+# DexEngine — privacy_guard attribute + provider wrapping
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def _minimal_config_path(tmp_path: Any) -> Any:
+    """Write a minimal dex.yaml — just enough for DexEngine to start."""
+    yaml = tmp_path / "dex.yaml"
+    yaml.write_text(
+        """
+project:
+  name: PrivacyGuardWiringTest
+  version: 0.1.0
+data:
+  engine: duckdb
+secops:
+  guard:
+    enabled: true
+    allow_local: true
+    strategies:
+      email: hash
+"""
+    )
+    return yaml
+
+
+class TestEngineWiring:
+    def test_engine_exposes_privacy_guard(self, _minimal_config_path: Any) -> None:
+        from dataenginex.engine import DexEngine
+        from dataenginex.secops import PrivacyGuard
+
+        engine = DexEngine(_minimal_config_path)
+        assert hasattr(engine, "privacy_guard")
+        assert isinstance(engine.privacy_guard, PrivacyGuard)
+
+    def test_engine_guard_reflects_dex_yaml(self, _minimal_config_path: Any) -> None:
+        from dataenginex.engine import DexEngine
+
+        engine = DexEngine(_minimal_config_path)
+        assert engine.privacy_guard.config.enabled is True
+        assert engine.privacy_guard.config.strategies[PIIType.EMAIL] == MaskingStrategy.HASH
+
+    def test_engine_providers_are_wrapped(self, _minimal_config_path: Any) -> None:
+        from dataenginex.ai.routing.guarded import GuardedProvider
+        from dataenginex.engine import DexEngine
+
+        engine = DexEngine(_minimal_config_path)
+        if not hasattr(engine, "model_router"):
+            pytest.skip("model_router not initialized (no providers available)")
+        for name, provider in engine.model_router._providers.items():  # noqa: SLF001
+            assert isinstance(provider, GuardedProvider), (
+                f"provider {name!r} should be guard-wrapped"
+            )
+            assert provider.target == name
+
+    def test_guarded_ollama_bypasses_local(self, _minimal_config_path: Any) -> None:
+        from dataenginex.engine import DexEngine
+
+        engine = DexEngine(_minimal_config_path)
+        # Verify ollama is wrapped and would bypass scan on local
+        if not hasattr(engine, "model_router"):
+            pytest.skip("model_router not initialized")
+        ollama = engine.model_router._providers.get("ollama")  # noqa: SLF001
+        if ollama is None:
+            pytest.skip("ollama provider not present")
+        # Process a known-PII prompt with target=ollama via the engine's guard
+        result = engine.privacy_guard.process("Email alice@example.com", target="ollama")
+        assert result.bypassed_local is True
+
+    def test_engine_with_block_on_detect(self, tmp_path: Any) -> None:
+        """Engine configured with block_on_detect routes through correctly."""
+        from dataenginex.engine import DexEngine
+        from dataenginex.secops import PrivacyBlocked
+
+        yaml = tmp_path / "dex.yaml"
+        yaml.write_text(
+            """
+project:
+  name: BlockTest
+  version: 0.1.0
+secops:
+  guard:
+    enabled: true
+    allow_local: false
+    block_on_detect: true
+"""
+        )
+        engine = DexEngine(yaml)
+        assert engine.privacy_guard.config.block_on_detect is True
+
+        # Direct guard invocation (no real provider needed) — verifies the
+        # blocked path is configured end-to-end from yaml → engine → guard.
+        result = engine.privacy_guard.process(
+            "Email me at alice@example.com",
+            target="anthropic",
+        )
+        assert result.blocked is True
+
+        # And via GuardedProvider with a fake inner:
+        from dataenginex.ai.routing.guarded import GuardedProvider
+        from dataenginex.ai.routing.router import BaseProvider
+
+        class _Spy(BaseProvider):
+            calls = 0
+
+            def generate(self, prompt: str, **kwargs: Any) -> str:
+                _Spy.calls += 1
+                return prompt
+
+        wrapped = GuardedProvider(_Spy(), engine.privacy_guard, target="anthropic")
+        with pytest.raises(PrivacyBlocked):
+            wrapped.generate("SSN 123-45-6789")
+        assert _Spy.calls == 0  # blocked before reaching inner

--- a/tests/unit/test_secops_engine_and_cli.py
+++ b/tests/unit/test_secops_engine_and_cli.py
@@ -1,0 +1,287 @@
+"""Tests for secops engine wiring (AuditLogger) + validate_secops + dex secops CLI."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from click.testing import CliRunner
+
+from dataenginex.cli.main import dex
+from dataenginex.config.loader import validate_config
+from dataenginex.config.schema import (
+    AuditConfig,
+    DexConfig,
+    GuardConfig,
+    ProjectConfig,
+    SecopsConfig,
+)
+
+# ---------------------------------------------------------------------------
+# _validate_secops — part of validate_config
+# ---------------------------------------------------------------------------
+
+
+class TestValidateSecops:
+    def test_valid_strategies_produce_no_errors(self) -> None:
+        cfg = DexConfig(
+            project=ProjectConfig(name="t"),
+            secops=SecopsConfig(
+                guard=GuardConfig(strategies={"email": "hash", "ssn": "redact"})
+            ),
+        )
+        hard = [e for e in validate_config(cfg) if not e.startswith("Warning:")]
+        assert hard == []
+
+    def test_unknown_pii_type_is_hard_error(self) -> None:
+        cfg = DexConfig(
+            project=ProjectConfig(name="t"),
+            secops=SecopsConfig(guard=GuardConfig(strategies={"unicorn": "hash"})),
+        )
+        errors = validate_config(cfg)
+        assert any("unknown PII type" in e and "unicorn" in e for e in errors)
+
+    def test_unknown_masking_strategy_is_hard_error(self) -> None:
+        cfg = DexConfig(
+            project=ProjectConfig(name="t"),
+            secops=SecopsConfig(guard=GuardConfig(strategies={"email": "obfuscate_lol"})),
+        )
+        errors = validate_config(cfg)
+        assert any("unknown masking strategy" in e and "obfuscate_lol" in e for e in errors)
+
+    def test_both_unknown_generates_two_errors(self) -> None:
+        cfg = DexConfig(
+            project=ProjectConfig(name="t"),
+            secops=SecopsConfig(guard=GuardConfig(strategies={"bad_type": "bad_strat"})),
+        )
+        errors = validate_config(cfg)
+        secops_errors = [e for e in errors if "secops.guard" in e]
+        assert len(secops_errors) == 2
+
+    def test_empty_strategies_is_valid(self) -> None:
+        cfg = DexConfig(project=ProjectConfig(name="t"))
+        hard = [e for e in validate_config(cfg) if not e.startswith("Warning:")]
+        assert hard == []
+
+
+# ---------------------------------------------------------------------------
+# AuditConfig schema
+# ---------------------------------------------------------------------------
+
+
+class TestAuditConfigSchema:
+    def test_defaults(self) -> None:
+        a = AuditConfig()
+        assert a.enabled is False
+        assert a.db_path == ""
+
+    def test_enabled_with_memory_path(self) -> None:
+        a = AuditConfig(enabled=True, db_path="")
+        assert a.enabled is True
+        assert a.db_path == ""
+
+    def test_enabled_with_file_path(self) -> None:
+        a = AuditConfig(enabled=True, db_path="audit.db")
+        assert a.db_path == "audit.db"
+
+
+# ---------------------------------------------------------------------------
+# Engine — AuditLogger wiring
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def _yaml_audit_disabled(tmp_path: Any) -> Any:
+    p = tmp_path / "dex.yaml"
+    p.write_text(
+        """
+project:
+  name: AuditWiringTest
+  version: 0.1.0
+secops:
+  audit:
+    enabled: false
+  guard:
+    enabled: true
+"""
+    )
+    return p
+
+
+@pytest.fixture
+def _yaml_audit_memory(tmp_path: Any) -> Any:
+    p = tmp_path / "dex.yaml"
+    p.write_text(
+        """
+project:
+  name: AuditMemoryTest
+  version: 0.1.0
+secops:
+  audit:
+    enabled: true
+    db_path: ""
+  guard:
+    enabled: true
+"""
+    )
+    return p
+
+
+@pytest.fixture
+def _yaml_audit_file(tmp_path: Any) -> Any:
+    p = tmp_path / "dex.yaml"
+    p.write_text(
+        """
+project:
+  name: AuditFileTest
+  version: 0.1.0
+secops:
+  audit:
+    enabled: true
+    db_path: "secops_audit.db"
+  guard:
+    enabled: true
+"""
+    )
+    return p
+
+
+class TestEngineAuditWiring:
+    def test_audit_disabled_secops_audit_is_none(self, _yaml_audit_disabled: Any) -> None:
+        from dataenginex.engine import DexEngine
+
+        engine = DexEngine(_yaml_audit_disabled)
+        assert engine.secops_audit is None
+        assert engine.privacy_guard._audit is None  # noqa: SLF001
+
+    def test_audit_memory_creates_audit_logger(self, _yaml_audit_memory: Any) -> None:
+        from dataenginex.engine import DexEngine
+        from dataenginex.secops import AuditLogger
+
+        engine = DexEngine(_yaml_audit_memory)
+        assert isinstance(engine.secops_audit, AuditLogger)
+        assert engine.privacy_guard._audit is engine.secops_audit  # noqa: SLF001
+
+    def test_audit_file_resolves_under_dex_dir(self, _yaml_audit_file: Any) -> None:
+        from dataenginex.engine import DexEngine
+        from dataenginex.secops import AuditLogger
+
+        engine = DexEngine(_yaml_audit_file)
+        assert isinstance(engine.secops_audit, AuditLogger)
+        # The db file should exist under the project's .dex/ directory
+        expected = engine._dex_dir / "secops_audit.db"  # noqa: SLF001
+        assert expected.exists()
+        # Clean up
+        engine.secops_audit.close()
+
+    def test_audit_guard_records_event_on_pii(self, _yaml_audit_memory: Any) -> None:
+        from dataenginex.engine import DexEngine
+
+        engine = DexEngine(_yaml_audit_memory)
+        # allow_local is True by default, so use a cloud target
+        engine.privacy_guard.process("Email me at alice@example.com", target="openai")
+        assert len(engine.secops_audit.events) >= 1
+
+
+# ---------------------------------------------------------------------------
+# dex secops CLI
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def _minimal_yaml(tmp_path: Any) -> Any:
+    p = tmp_path / "dex.yaml"
+    p.write_text(
+        """
+project:
+  name: CLITest
+  version: 0.1.0
+secops:
+  guard:
+    enabled: true
+    allow_local: true
+    block_on_detect: false
+    strategies:
+      email: hash
+  audit:
+    enabled: false
+"""
+    )
+    return p
+
+
+class TestSecopsStatusCommand:
+    def test_status_exits_zero(self, _minimal_yaml: Any) -> None:
+        runner = CliRunner()
+        result = runner.invoke(dex, ["secops", "status", "--config", str(_minimal_yaml)])
+        assert result.exit_code == 0, result.output
+
+    def test_status_shows_enabled(self, _minimal_yaml: Any) -> None:
+        runner = CliRunner()
+        result = runner.invoke(dex, ["secops", "status", "--config", str(_minimal_yaml)])
+        assert "Enabled" in result.output
+
+    def test_status_shows_strategy(self, _minimal_yaml: Any) -> None:
+        runner = CliRunner()
+        result = runner.invoke(dex, ["secops", "status", "--config", str(_minimal_yaml)])
+        assert "email" in result.output
+        assert "hash" in result.output
+
+    def test_status_shows_audit_section(self, _minimal_yaml: Any) -> None:
+        runner = CliRunner()
+        result = runner.invoke(dex, ["secops", "status", "--config", str(_minimal_yaml)])
+        assert "Audit" in result.output
+
+
+class TestSecopsScanCommand:
+    def test_scan_clean_text_exits_zero(self, _minimal_yaml: Any) -> None:
+        runner = CliRunner()
+        result = runner.invoke(
+            dex, ["secops", "scan", "hello world", "--config", str(_minimal_yaml)]
+        )
+        assert result.exit_code == 0, result.output
+        assert "No PII" in result.output
+
+    def test_scan_email_detected(self, _minimal_yaml: Any) -> None:
+        runner = CliRunner()
+        result = runner.invoke(
+            dex,
+            ["secops", "scan", "Email me at alice@example.com", "--config", str(_minimal_yaml)],
+        )
+        assert result.exit_code == 0, result.output
+        assert "email" in result.output.lower()
+
+    def test_scan_local_target_bypassed(self, _minimal_yaml: Any) -> None:
+        runner = CliRunner()
+        result = runner.invoke(
+            dex,
+            [
+                "secops", "scan", "alice@example.com",
+                "--config", str(_minimal_yaml),
+                "--target", "ollama",
+            ],
+        )
+        assert result.exit_code == 0, result.output
+        assert "Bypass" in result.output or "local" in result.output.lower()
+
+    def test_scan_block_on_detect(self, tmp_path: Any) -> None:
+        p = tmp_path / "block.yaml"
+        p.write_text(
+            """
+project:
+  name: BlockScan
+  version: 0.1.0
+secops:
+  guard:
+    enabled: true
+    allow_local: false
+    block_on_detect: true
+"""
+        )
+        runner = CliRunner()
+        result = runner.invoke(
+            dex,
+            ["secops", "scan", "SSN 123-45-6789", "--config", str(p), "--target", "openai"],
+        )
+        assert result.exit_code == 0, result.output
+        assert "BLOCK" in result.output.upper()

--- a/tests/unit/test_secops_engine_and_cli.py
+++ b/tests/unit/test_secops_engine_and_cli.py
@@ -26,9 +26,7 @@ class TestValidateSecops:
     def test_valid_strategies_produce_no_errors(self) -> None:
         cfg = DexConfig(
             project=ProjectConfig(name="t"),
-            secops=SecopsConfig(
-                guard=GuardConfig(strategies={"email": "hash", "ssn": "redact"})
-            ),
+            secops=SecopsConfig(guard=GuardConfig(strategies={"email": "hash", "ssn": "redact"})),
         )
         hard = [e for e in validate_config(cfg) if not e.startswith("Warning:")]
         assert hard == []
@@ -256,9 +254,13 @@ class TestSecopsScanCommand:
         result = runner.invoke(
             dex,
             [
-                "secops", "scan", "alice@example.com",
-                "--config", str(_minimal_yaml),
-                "--target", "ollama",
+                "secops",
+                "scan",
+                "alice@example.com",
+                "--config",
+                str(_minimal_yaml),
+                "--target",
+                "ollama",
             ],
         )
         assert result.exit_code == 0, result.output

--- a/tests/unit/test_secops_guard.py
+++ b/tests/unit/test_secops_guard.py
@@ -1,0 +1,328 @@
+"""Tests for PrivacyGuard, GuardedProvider, and string-level PII helpers."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from dataenginex.ai.routing.guarded import GuardedProvider
+from dataenginex.ai.routing.router import BaseProvider
+from dataenginex.secops import (
+    AuditLogger,
+    MaskingEngine,
+    MaskingStrategy,
+    PIIDetector,
+    PIIType,
+    PrivacyBlocked,
+    PrivacyGuard,
+    PrivacyGuardConfig,
+    TextMatch,
+)
+
+# ---------------------------------------------------------------------------
+# PIIDetector.scan_text
+# ---------------------------------------------------------------------------
+
+
+class TestScanText:
+    def test_empty_text_returns_no_matches(self) -> None:
+        det = PIIDetector()
+        assert det.scan_text("") == []
+
+    def test_text_with_no_pii_returns_no_matches(self) -> None:
+        det = PIIDetector()
+        assert det.scan_text("Just a regular sentence with no sensitive data.") == []
+
+    def test_detects_email(self) -> None:
+        det = PIIDetector()
+        matches = det.scan_text("Please reply to alice@example.com when ready.")
+        assert len(matches) == 1
+        assert matches[0].pii_type == PIIType.EMAIL
+        assert matches[0].value == "alice@example.com"
+
+    def test_detects_ssn(self) -> None:
+        det = PIIDetector()
+        matches = det.scan_text("SSN is 123-45-6789, do not share.")
+        assert any(m.pii_type == PIIType.SSN for m in matches)
+
+    def test_detects_credit_card(self) -> None:
+        det = PIIDetector()
+        matches = det.scan_text("Card: 4111-1111-1111-1111 expires soon.")
+        assert any(m.pii_type == PIIType.CREDIT_CARD for m in matches)
+
+    def test_detects_multiple_pii_in_one_string(self) -> None:
+        det = PIIDetector()
+        matches = det.scan_text("Email: bob@foo.com SSN: 987-65-4321")
+        types = {m.pii_type for m in matches}
+        assert PIIType.EMAIL in types
+        assert PIIType.SSN in types
+
+    def test_matches_returned_sorted_by_start(self) -> None:
+        det = PIIDetector()
+        text = "first bob@foo.com then later 192.168.1.1"
+        matches = det.scan_text(text)
+        starts = [m.start for m in matches]
+        assert starts == sorted(starts)
+
+    def test_match_offsets_are_correct(self) -> None:
+        det = PIIDetector()
+        text = "contact: alice@example.com"
+        matches = det.scan_text(text)
+        assert len(matches) == 1
+        assert text[matches[0].start : matches[0].end] == "alice@example.com"
+
+    def test_high_threshold_filters_low_confidence(self) -> None:
+        # DOB has confidence 0.60 — should be filtered at threshold 0.85
+        det_strict = PIIDetector(confidence_threshold=0.85)
+        text = "Born 1990-01-15"
+        assert det_strict.scan_text(text) == []
+        det_loose = PIIDetector(confidence_threshold=0.5)
+        assert any(m.pii_type == PIIType.DATE_OF_BIRTH for m in det_loose.scan_text(text))
+
+
+# ---------------------------------------------------------------------------
+# MaskingEngine.mask_text
+# ---------------------------------------------------------------------------
+
+
+class TestMaskText:
+    def test_no_matches_returns_text_unchanged(self) -> None:
+        eng = MaskingEngine()
+        assert eng.mask_text("hello world", []) == "hello world"
+
+    def test_redacts_email_by_default(self) -> None:
+        eng = MaskingEngine(default_strategy=MaskingStrategy.REDACT)
+        det = PIIDetector()
+        text = "Reply to alice@example.com please"
+        masked = eng.mask_text(text, det.scan_text(text))
+        assert "alice@example.com" not in masked
+        assert "[REDACTED]" in masked
+
+    def test_per_type_strategy_overrides_default(self) -> None:
+        eng = MaskingEngine(default_strategy=MaskingStrategy.REDACT)
+        det = PIIDetector()
+        text = "Reach me at alice@example.com"
+        masked = eng.mask_text(
+            text,
+            det.scan_text(text),
+            strategies={PIIType.EMAIL: MaskingStrategy.HASH},
+        )
+        assert "alice@example.com" not in masked
+        assert "[REDACTED]" not in masked  # HASH used instead
+
+    def test_multiple_replacements_preserve_indices(self) -> None:
+        # Two emails — masking must not shift the second match's indices
+        eng = MaskingEngine(default_strategy=MaskingStrategy.REDACT)
+        det = PIIDetector()
+        text = "From: a@x.com To: b@y.com"
+        masked = eng.mask_text(text, det.scan_text(text))
+        assert "a@x.com" not in masked
+        assert "b@y.com" not in masked
+        assert masked.count("[REDACTED]") == 2
+
+    def test_partial_keeps_last_chars(self) -> None:
+        eng = MaskingEngine(default_strategy=MaskingStrategy.PARTIAL, partial_keep_last=4)
+        det = PIIDetector()
+        text = "ssn 123-45-6789"
+        masked = eng.mask_text(text, det.scan_text(text))
+        # PARTIAL keeps the last 4 chars of "123-45-6789" → "6789"
+        assert masked.endswith("6789")
+
+
+# ---------------------------------------------------------------------------
+# PrivacyGuard.process
+# ---------------------------------------------------------------------------
+
+
+class TestPrivacyGuard:
+    def test_disabled_passes_through(self) -> None:
+        guard = PrivacyGuard(config=PrivacyGuardConfig(enabled=False))
+        result = guard.process("Email alice@example.com", target="openai")
+        assert result.safe_prompt == "Email alice@example.com"
+        assert result.detections == ()
+        assert not result.blocked
+
+    def test_local_target_bypassed_by_default(self) -> None:
+        guard = PrivacyGuard()
+        result = guard.process("Email alice@example.com", target="ollama")
+        assert result.bypassed_local is True
+        assert result.safe_prompt == "Email alice@example.com"
+        assert result.detections == ()
+
+    def test_local_bypass_can_be_disabled(self) -> None:
+        guard = PrivacyGuard(config=PrivacyGuardConfig(allow_local=False))
+        result = guard.process("Email alice@example.com", target="ollama")
+        assert result.bypassed_local is False
+        assert len(result.detections) == 1
+        assert "alice@example.com" not in result.safe_prompt
+
+    def test_remote_target_with_no_pii_passes_through(self) -> None:
+        guard = PrivacyGuard()
+        result = guard.process("What is 2+2?", target="openai")
+        assert result.safe_prompt == "What is 2+2?"
+        assert result.detections == ()
+        assert not result.blocked
+
+    def test_remote_target_with_pii_gets_masked(self) -> None:
+        guard = PrivacyGuard()
+        result = guard.process("Email me at alice@example.com", target="openai")
+        assert "alice@example.com" not in result.safe_prompt
+        assert len(result.detections) == 1
+        assert result.detections[0].pii_type == PIIType.EMAIL
+        assert not result.blocked
+
+    def test_block_on_detect_returns_blocked_result(self) -> None:
+        guard = PrivacyGuard(config=PrivacyGuardConfig(block_on_detect=True))
+        result = guard.process("SSN 123-45-6789", target="anthropic")
+        assert result.blocked is True
+        assert result.safe_prompt == "SSN 123-45-6789"  # untouched
+        assert len(result.detections) >= 1
+
+    def test_block_on_detect_does_not_fire_on_clean_prompt(self) -> None:
+        guard = PrivacyGuard(config=PrivacyGuardConfig(block_on_detect=True))
+        result = guard.process("hello world", target="openai")
+        assert not result.blocked
+
+    def test_per_type_strategy_used_when_masking(self) -> None:
+        cfg = PrivacyGuardConfig(strategies={PIIType.EMAIL: MaskingStrategy.HASH})
+        guard = PrivacyGuard(config=cfg)
+        result = guard.process("Reach me at alice@example.com", target="openai")
+        assert "alice@example.com" not in result.safe_prompt
+        assert "[REDACTED]" not in result.safe_prompt  # HASH used instead
+
+    def test_custom_local_targets_bypass(self) -> None:
+        cfg = PrivacyGuardConfig(local_targets=frozenset({"my_self_hosted_llm"}))
+        guard = PrivacyGuard(config=cfg)
+        result = guard.process("a@x.com", target="my_self_hosted_llm")
+        assert result.bypassed_local is True
+
+    def test_audit_logger_receives_event_on_mask(self) -> None:
+        audit = AuditLogger()
+        guard = PrivacyGuard(audit_logger=audit)
+        guard.process("Email alice@example.com", target="openai")
+        events = audit.events
+        assert len(events) == 1
+        assert events[0].dataset_name == "outbound:openai"
+        assert events[0].actor == "privacy_guard"
+        assert "email" in events[0].pii_fields
+        audit.close()
+
+    def test_audit_logger_records_block(self) -> None:
+        audit = AuditLogger()
+        guard = PrivacyGuard(
+            config=PrivacyGuardConfig(block_on_detect=True),
+            audit_logger=audit,
+        )
+        guard.process("Email alice@example.com", target="openai")
+        events = audit.events
+        assert len(events) == 1
+        assert events[0].metadata["blocked"] is True
+        audit.close()
+
+    def test_audit_logger_skipped_on_clean_prompt(self) -> None:
+        audit = AuditLogger()
+        guard = PrivacyGuard(audit_logger=audit)
+        guard.process("hello world", target="openai")
+        # No PII matches → no audit event
+        assert audit.events == []
+        audit.close()
+
+
+# ---------------------------------------------------------------------------
+# GuardedProvider — wires PrivacyGuard into the provider call path
+# ---------------------------------------------------------------------------
+
+
+class _RecordingProvider(BaseProvider):
+    """Test double that captures the prompt it receives."""
+
+    def __init__(self) -> None:
+        self.received: list[str] = []
+
+    def generate(self, prompt: str, **kwargs: Any) -> str:
+        self.received.append(prompt)
+        return f"echo: {prompt[:32]}"
+
+
+class TestGuardedProvider:
+    def test_target_derived_from_inner_class_name(self) -> None:
+        inner = _RecordingProvider()
+        wrapped = GuardedProvider(inner, PrivacyGuard())
+        # _RecordingProvider → "recording"
+        assert wrapped.target == "recording"
+
+    def test_explicit_target_overrides_derivation(self) -> None:
+        wrapped = GuardedProvider(_RecordingProvider(), PrivacyGuard(), target="openai")
+        assert wrapped.target == "openai"
+
+    def test_clean_prompt_passes_through_unmodified(self) -> None:
+        inner = _RecordingProvider()
+        wrapped = GuardedProvider(inner, PrivacyGuard(), target="openai")
+        wrapped.generate("hello world")
+        assert inner.received == ["hello world"]
+
+    def test_pii_in_prompt_is_masked_before_inner_call(self) -> None:
+        inner = _RecordingProvider()
+        wrapped = GuardedProvider(inner, PrivacyGuard(), target="openai")
+        wrapped.generate("Email me at alice@example.com")
+        assert len(inner.received) == 1
+        assert "alice@example.com" not in inner.received[0]
+
+    def test_local_target_bypasses_guard(self) -> None:
+        inner = _RecordingProvider()
+        wrapped = GuardedProvider(inner, PrivacyGuard(), target="ollama")
+        wrapped.generate("Email alice@example.com")
+        # Ollama is local → guard bypassed → inner sees original
+        assert inner.received == ["Email alice@example.com"]
+
+    def test_block_on_detect_raises_privacyblocked(self) -> None:
+        inner = _RecordingProvider()
+        cfg = PrivacyGuardConfig(block_on_detect=True)
+        wrapped = GuardedProvider(inner, PrivacyGuard(config=cfg), target="openai")
+        with pytest.raises(PrivacyBlocked) as exc:
+            wrapped.generate("SSN 123-45-6789")
+        # Inner never called
+        assert inner.received == []
+        # Exception carries detections
+        assert len(exc.value.detections) >= 1
+        assert exc.value.target == "openai"
+
+    def test_kwargs_pass_through_to_inner(self) -> None:
+        class _KwargsProvider(BaseProvider):
+            def __init__(self) -> None:
+                self.last_kwargs: dict[str, Any] = {}
+
+            def generate(self, prompt: str, **kwargs: Any) -> str:
+                self.last_kwargs = kwargs
+                return "ok"
+
+        inner = _KwargsProvider()
+        wrapped = GuardedProvider(inner, PrivacyGuard(), target="openai")
+        wrapped.generate("hello", temperature=0.7, max_tokens=100)
+        assert inner.last_kwargs == {"temperature": 0.7, "max_tokens": 100}
+
+
+# ---------------------------------------------------------------------------
+# Overlapping-match deduplication
+# ---------------------------------------------------------------------------
+
+
+class TestOverlappingMatches:
+    def test_overlapping_spans_deduplicated(self) -> None:
+        # A phone-number-like span and a credit-card-like span overlap;
+        # the scanner should keep only the higher-confidence one.
+        det = PIIDetector()
+        # 4111-1111-1111-1111 matches both CREDIT_CARD (0.85) and PHONE (0.80)
+        matches = det.scan_text("Card 4111-1111-1111-1111 is here")
+        # CREDIT_CARD should win (higher confidence)
+        kept_types = {m.pii_type for m in matches}
+        # PHONE pattern matches sub-spans; dedup should prefer CC
+        assert PIIType.CREDIT_CARD in kept_types
+
+    def test_textmatch_is_frozen(self) -> None:
+        from dataclasses import FrozenInstanceError
+
+        m = TextMatch(pii_type=PIIType.EMAIL, value="a@b.c", start=0, end=5)
+        with pytest.raises(FrozenInstanceError):
+            m.value = "x"  # type: ignore[misc]

--- a/tests/unit/test_spark_connector.py
+++ b/tests/unit/test_spark_connector.py
@@ -1,0 +1,209 @@
+"""Tests for dataenginex.data.connectors.spark — SparkConnector."""
+
+from __future__ import annotations
+
+import sys
+from collections.abc import Generator
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+def _make_arrow_table(data: list[dict[str, Any]]) -> MagicMock:
+    """Build a mock Arrow table from a list of dicts."""
+    cols: list[str] = list(data[0].keys()) if data else []
+    mock = MagicMock()
+    mock.schema.names = cols
+    mock.num_rows = len(data)
+    mock.to_pydict.return_value = {col: [row[col] for row in data] for col in cols}
+    return mock
+
+
+def _make_spark_session(arrow_table: MagicMock | None = None) -> MagicMock:
+    """Return a mock SparkSession whose read chain returns a mock DataFrame."""
+    session = MagicMock()
+    df = MagicMock()
+    df.toArrow.return_value = arrow_table or _make_arrow_table([])
+
+    reader = MagicMock()
+    reader.format.return_value = reader
+    reader.options.return_value = reader
+    reader.load.return_value = df
+    session.read = reader
+
+    builder = MagicMock()
+    builder.master.return_value = builder
+    builder.appName.return_value = builder
+    builder.getOrCreate.return_value = session
+    session.builder = builder
+
+    return session
+
+
+@pytest.fixture()
+def mock_pyspark(monkeypatch: pytest.MonkeyPatch) -> Generator[MagicMock]:
+    """Inject a mock pyspark into sys.modules and patch _PYSPARK_AVAILABLE."""
+    mock_session = _make_spark_session()
+
+    mock_pyspark_mod = MagicMock()
+    mock_sql_mod = MagicMock()
+    mock_sql_mod.SparkSession = MagicMock()
+    mock_sql_mod.SparkSession.builder = mock_session.builder
+
+    with (
+        patch.dict(sys.modules, {"pyspark": mock_pyspark_mod, "pyspark.sql": mock_sql_mod}),
+        patch("dataenginex.data.connectors.spark._PYSPARK_AVAILABLE", True),
+    ):
+        yield mock_session
+
+
+class TestSparkConnectorImportGuard:
+    def test_raises_import_error_when_pyspark_missing(self) -> None:
+        with patch("dataenginex.data.connectors.spark._PYSPARK_AVAILABLE", False):
+            from dataenginex.data.connectors.spark import SparkConnector
+
+            with pytest.raises(ImportError, match="PySpark is required"):
+                SparkConnector()
+
+    def test_registered_as_spark(self) -> None:
+        from dataenginex.data.connectors import connector_registry
+        from dataenginex.data.connectors.spark import SparkConnector
+
+        assert connector_registry.get("spark") is SparkConnector
+
+
+class TestSparkConnectorConnect:
+    def test_connect_creates_session(self, mock_pyspark: MagicMock) -> None:
+        with patch("dataenginex.data.connectors.spark._PYSPARK_AVAILABLE", True):
+            from dataenginex.data.connectors.spark import SparkConnector
+
+            c = SparkConnector()
+            c.connect()
+            assert c._spark is not None
+            c.disconnect()
+
+    def test_disconnect_clears_session(self, mock_pyspark: MagicMock) -> None:
+        with patch("dataenginex.data.connectors.spark._PYSPARK_AVAILABLE", True):
+            from dataenginex.data.connectors.spark import SparkConnector
+
+            c = SparkConnector()
+            c.connect()
+            c.disconnect()
+            assert c._spark is None
+
+    def test_disconnect_before_connect_is_safe(self, mock_pyspark: MagicMock) -> None:
+        with patch("dataenginex.data.connectors.spark._PYSPARK_AVAILABLE", True):
+            from dataenginex.data.connectors.spark import SparkConnector
+
+            SparkConnector().disconnect()  # should not raise
+
+    def test_health_check_false_when_disconnected(self, mock_pyspark: MagicMock) -> None:
+        with patch("dataenginex.data.connectors.spark._PYSPARK_AVAILABLE", True):
+            from dataenginex.data.connectors.spark import SparkConnector
+
+            assert SparkConnector().health_check() is False
+
+
+class TestSparkConnectorRead:
+    def _connector(self, path: str | None = "/data/test") -> Any:
+        from dataenginex.data.connectors.spark import SparkConnector
+
+        return SparkConnector(path=path)
+
+    def test_read_not_connected_raises(self, mock_pyspark: MagicMock) -> None:
+        with patch("dataenginex.data.connectors.spark._PYSPARK_AVAILABLE", True):
+            c = self._connector()
+            with pytest.raises(RuntimeError, match="Not connected"):
+                c.read()
+
+    def test_read_no_path_raises(self, mock_pyspark: MagicMock) -> None:
+        with patch("dataenginex.data.connectors.spark._PYSPARK_AVAILABLE", True):
+            c = self._connector(path=None)
+            c._spark = mock_pyspark
+            with pytest.raises(ValueError, match="No path specified"):
+                c.read()
+
+    def test_read_returns_rows(self, mock_pyspark: MagicMock) -> None:
+        data = [{"id": 1, "name": "alice"}, {"id": 2, "name": "bob"}]
+        arrow = _make_arrow_table(data)
+
+        df = MagicMock()
+        df.toArrow.return_value = arrow
+        mock_pyspark.read.format.return_value.options.return_value.load.return_value = df
+        mock_pyspark.read.format.return_value.load.return_value = df
+
+        with patch("dataenginex.data.connectors.spark._PYSPARK_AVAILABLE", True):
+            c = self._connector()
+            c._spark = mock_pyspark
+            rows = c.read()
+
+        assert len(rows) == 2
+        assert rows[0]["name"] == "alice"
+
+    def test_read_uses_table_arg_over_path(self, mock_pyspark: MagicMock) -> None:
+        data = [{"x": 42}]
+        arrow = _make_arrow_table(data)
+
+        df = MagicMock()
+        df.toArrow.return_value = arrow
+        mock_pyspark.read.format.return_value.options.return_value.load.return_value = df
+        mock_pyspark.read.format.return_value.load.return_value = df
+
+        with patch("dataenginex.data.connectors.spark._PYSPARK_AVAILABLE", True):
+            c = self._connector(path="/default/path")
+            c._spark = mock_pyspark
+            c.read(table="/override/path")
+
+        mock_pyspark.read.format.return_value.load.assert_called_with("/override/path")
+
+    def test_read_exception_with_default_returns_default(self, mock_pyspark: MagicMock) -> None:
+        mock_pyspark.read.format.return_value.load.side_effect = RuntimeError("oops")
+        mock_pyspark.read.format.return_value.options.return_value.load.side_effect = RuntimeError(
+            "oops"
+        )
+
+        with patch("dataenginex.data.connectors.spark._PYSPARK_AVAILABLE", True):
+            c = self._connector()
+            c._spark = mock_pyspark
+            assert c.read(default=[]) == []
+
+    def test_read_exception_without_default_raises(self, mock_pyspark: MagicMock) -> None:
+        mock_pyspark.read.format.return_value.load.side_effect = RuntimeError("boom")
+        mock_pyspark.read.format.return_value.options.return_value.load.side_effect = RuntimeError(
+            "boom"
+        )
+
+        with patch("dataenginex.data.connectors.spark._PYSPARK_AVAILABLE", True):
+            c = self._connector()
+            c._spark = mock_pyspark
+            with pytest.raises(RuntimeError, match="boom"):
+                c.read()
+
+
+class TestSparkConnectorWrite:
+    def test_write_not_connected_raises(self, mock_pyspark: MagicMock) -> None:
+        with patch("dataenginex.data.connectors.spark._PYSPARK_AVAILABLE", True):
+            from dataenginex.data.connectors.spark import SparkConnector
+
+            c = SparkConnector()
+            with pytest.raises(RuntimeError, match="Not connected"):
+                c.write([{"x": 1}])
+
+    def test_write_unsupported_type_raises(self, mock_pyspark: MagicMock) -> None:
+        with patch("dataenginex.data.connectors.spark._PYSPARK_AVAILABLE", True):
+            from dataenginex.data.connectors.spark import SparkConnector
+
+            c = SparkConnector()
+            c._spark = mock_pyspark
+            with pytest.raises(TypeError):
+                c.write("not a list")
+
+    def test_write_empty_list_is_noop(self, mock_pyspark: MagicMock) -> None:
+        with patch("dataenginex.data.connectors.spark._PYSPARK_AVAILABLE", True):
+            from dataenginex.data.connectors.spark import SparkConnector
+
+            c = SparkConnector()
+            c._spark = mock_pyspark
+            c.write([])  # should not raise or call createDataFrame
+            mock_pyspark.createDataFrame.assert_not_called()

--- a/tests/unit/test_vectorstore_extended.py
+++ b/tests/unit/test_vectorstore_extended.py
@@ -1,0 +1,287 @@
+"""Extended tests for dataenginex.ai.vectorstore — InMemoryBackend, RAGPipeline, Document."""
+
+from __future__ import annotations
+
+import pytest
+
+from dataenginex.ai.vectorstore import (
+    Document,
+    InMemoryBackend,
+    RAGPipeline,
+    SearchResult,
+    VectorStoreBackend,
+)
+
+# ── Document ──────────────────────────────────────────────────────────────────
+
+
+class TestDocument:
+    def test_default_id_generated(self) -> None:
+        d = Document(text="hello")
+        assert len(d.id) > 0
+
+    def test_ids_unique(self) -> None:
+        ids = {Document().id for _ in range(50)}
+        assert len(ids) == 50
+
+    def test_metadata_default_empty(self) -> None:
+        d = Document(text="x")
+        assert d.metadata == {}
+
+    def test_embedding_default_empty(self) -> None:
+        d = Document(text="x")
+        assert d.embedding == []
+
+    def test_custom_id(self) -> None:
+        d = Document(id="my-id", text="hello")
+        assert d.id == "my-id"
+
+
+# ── SearchResult ──────────────────────────────────────────────────────────────
+
+
+class TestSearchResult:
+    def test_fields(self) -> None:
+        doc = Document(text="test")
+        sr = SearchResult(document=doc, score=0.95)
+        assert sr.document is doc
+        assert sr.score == 0.95
+
+
+# ── VectorStoreBackend (ABC) ──────────────────────────────────────────────────
+
+
+class TestVectorStoreBackendABC:
+    def test_cannot_instantiate(self) -> None:
+        with pytest.raises(TypeError):
+            VectorStoreBackend()  # type: ignore[abstract]
+
+
+# ── InMemoryBackend ───────────────────────────────────────────────────────────
+
+
+def _vec(n: int, dim: int = 4) -> list[float]:
+    """Generate a simple normalised vector."""
+    import math
+
+    v = [float(i % (n + 1) + 1) for i in range(dim)]
+    mag = math.sqrt(sum(x * x for x in v)) or 1.0
+    return [x / mag for x in v]
+
+
+class TestInMemoryBackendUpsert:
+    def test_upsert_returns_count(self) -> None:
+        b = InMemoryBackend(dimension=4)
+        docs = [
+            Document(id="a", text="x", embedding=_vec(1)),
+            Document(id="b", text="y", embedding=_vec(2)),
+        ]
+        assert b.upsert(docs) == 2
+
+    def test_upsert_empty(self) -> None:
+        b = InMemoryBackend(dimension=4)
+        assert b.upsert([]) == 0
+
+    def test_upsert_updates_existing(self) -> None:
+        b = InMemoryBackend(dimension=4)
+        d1 = Document(id="x", text="old", embedding=_vec(1))
+        d2 = Document(id="x", text="new", embedding=_vec(2))
+        b.upsert([d1])
+        b.upsert([d2])
+        assert b.count() == 1
+        assert b.get("x").text == "new"  # type: ignore[union-attr]
+
+    def test_upsert_wrong_dimension_skipped(self) -> None:
+        b = InMemoryBackend(dimension=4)
+        bad = Document(id="bad", text="x", embedding=[1.0, 2.0])  # wrong dim
+        assert b.upsert([bad]) == 0
+        assert b.count() == 0
+
+    def test_upsert_no_embedding_allowed(self) -> None:
+        b = InMemoryBackend(dimension=4)
+        doc = Document(id="no-embed", text="x")  # empty embedding
+        assert b.upsert([doc]) == 1
+
+
+class TestInMemoryBackendQuery:
+    def _populated(self, dim: int = 4) -> InMemoryBackend:
+        b = InMemoryBackend(dimension=dim)
+        docs = [Document(id=str(i), text=f"doc {i}", embedding=_vec(i, dim)) for i in range(5)]
+        b.upsert(docs)
+        return b
+
+    def test_query_returns_results(self) -> None:
+        b = self._populated()
+        results = b.query(_vec(0), top_k=3)
+        assert len(results) <= 3
+        assert all(isinstance(r, SearchResult) for r in results)
+
+    def test_query_sorted_by_score_desc(self) -> None:
+        b = self._populated()
+        results = b.query(_vec(0), top_k=5)
+        scores = [r.score for r in results]
+        assert scores == sorted(scores, reverse=True)
+
+    def test_query_top_k_respected(self) -> None:
+        b = self._populated()
+        assert len(b.query(_vec(0), top_k=2)) == 2
+
+    def test_query_empty_store(self) -> None:
+        b = InMemoryBackend(dimension=4)
+        assert b.query(_vec(0)) == []
+
+    def test_query_skips_docs_without_embedding(self) -> None:
+        b = InMemoryBackend(dimension=4)
+        b.upsert([Document(id="no-embed", text="x")])
+        results = b.query(_vec(0))
+        assert results == []
+
+    def test_query_metadata_filter(self) -> None:
+        b = InMemoryBackend(dimension=4)
+        b.upsert(
+            [
+                Document(id="a", text="match", embedding=_vec(1), metadata={"type": "good"}),
+                Document(id="b", text="skip", embedding=_vec(2), metadata={"type": "bad"}),
+            ]
+        )
+        results = b.query(_vec(1), filter_metadata={"type": "good"})
+        assert all(r.document.metadata["type"] == "good" for r in results)
+
+    def test_query_metadata_filter_no_match(self) -> None:
+        b = InMemoryBackend(dimension=4)
+        b.upsert([Document(id="a", embedding=_vec(1), metadata={"type": "bad"})])
+        results = b.query(_vec(1), filter_metadata={"type": "good"})
+        assert results == []
+
+
+class TestInMemoryBackendCRUD:
+    def test_count_empty(self) -> None:
+        assert InMemoryBackend().count() == 0
+
+    def test_count_after_upsert(self) -> None:
+        b = InMemoryBackend(dimension=4)
+        b.upsert([Document(id="x", embedding=_vec(1))])
+        assert b.count() == 1
+
+    def test_get_existing(self) -> None:
+        b = InMemoryBackend(dimension=4)
+        doc = Document(id="myid", text="hello")
+        b.upsert([doc])
+        assert b.get("myid") is doc
+
+    def test_get_missing_returns_none(self) -> None:
+        b = InMemoryBackend()
+        assert b.get("nope") is None
+
+    def test_delete_existing(self) -> None:
+        b = InMemoryBackend(dimension=4)
+        b.upsert([Document(id="del")])
+        assert b.delete(["del"]) == 1
+        assert b.count() == 0
+
+    def test_delete_missing_returns_zero(self) -> None:
+        b = InMemoryBackend()
+        assert b.delete(["ghost"]) == 0
+
+    def test_delete_partial(self) -> None:
+        b = InMemoryBackend(dimension=4)
+        b.upsert([Document(id="a"), Document(id="b")])
+        assert b.delete(["a", "ghost"]) == 1
+        assert b.count() == 1
+
+    def test_clear(self) -> None:
+        b = InMemoryBackend(dimension=4)
+        b.upsert([Document(id="a"), Document(id="b")])
+        b.clear()
+        assert b.count() == 0
+
+
+class TestCosineSimilarity:
+    def test_identical_vectors_score_one(self) -> None:
+        v = _vec(1)
+        score = InMemoryBackend._cosine(v, v)
+        assert abs(score - 1.0) < 1e-6
+
+    def test_orthogonal_vectors_score_zero(self) -> None:
+        a = [1.0, 0.0, 0.0, 0.0]
+        b = [0.0, 1.0, 0.0, 0.0]
+        score = InMemoryBackend._cosine(a, b)
+        assert abs(score) < 1e-6
+
+    def test_zero_vector_no_crash(self) -> None:
+        score = InMemoryBackend._cosine([0.0, 0.0], [1.0, 0.0])
+        assert isinstance(score, float)
+
+
+class TestMatchesFilter:
+    def test_match_all_keys(self) -> None:
+        assert InMemoryBackend._matches_filter({"a": 1, "b": 2}, {"a": 1}) is True
+
+    def test_mismatch(self) -> None:
+        assert InMemoryBackend._matches_filter({"a": 1}, {"a": 2}) is False
+
+    def test_missing_key(self) -> None:
+        assert InMemoryBackend._matches_filter({}, {"a": 1}) is False
+
+
+# ── RAGPipeline ───────────────────────────────────────────────────────────────
+
+
+class TestRAGPipeline:
+    def _pipeline(self, dim: int = 4) -> RAGPipeline:
+        store = InMemoryBackend(dimension=dim)
+        embed_fn = lambda text: _vec(hash(text) % 100, dim)  # noqa: E731
+        return RAGPipeline(store=store, embed_fn=embed_fn, dimension=dim)
+
+    def test_ingest_strings(self) -> None:
+        rag = self._pipeline()
+        count = rag.ingest(["doc one", "doc two"])
+        assert count == 2
+
+    def test_ingest_with_metadata(self) -> None:
+        rag = self._pipeline()
+        count = rag.ingest(["hello"], metadata=[{"source": "test"}])
+        assert count == 1
+
+    def test_ingest_with_ids(self) -> None:
+        rag = self._pipeline()
+        rag.ingest(["text"], ids=["my-id"])
+        assert rag.store.get("my-id") is not None
+
+    def test_query_returns_results(self) -> None:
+        rag = self._pipeline()
+        rag.ingest(["alpha beta", "gamma delta"])
+        results = rag.query("alpha", top_k=2)
+        assert len(results) <= 2
+
+    def test_query_empty_store(self) -> None:
+        rag = self._pipeline()
+        assert rag.query("anything") == []
+
+    def test_store_attribute(self) -> None:
+        rag = self._pipeline()
+        assert isinstance(rag.store, InMemoryBackend)
+
+    def test_ingest_uses_hash_embed_fallback(self) -> None:
+        store = InMemoryBackend(dimension=4)
+        rag = RAGPipeline(store=store, embed_fn=None, dimension=4)
+        count = rag.ingest(["text using hash embed"])
+        assert count == 1
+
+    def test_build_context_returns_str(self) -> None:
+        rag = self._pipeline()
+        rag.ingest(["context document one", "context document two"])
+        ctx = rag.build_context("query", top_k=2)
+        assert isinstance(ctx, str)
+
+    def test_build_context_empty_store(self) -> None:
+        rag = self._pipeline()
+        ctx = rag.build_context("query")
+        assert ctx == ""
+
+    def test_build_context_respects_max_chars(self) -> None:
+        rag = self._pipeline()
+        long_text = "word " * 1000
+        rag.ingest([long_text, long_text])
+        ctx = rag.build_context("query", max_context_chars=50)
+        assert len(ctx) <= 60  # small margin for ID prefix

--- a/tests/unit/test_warehouse_transforms.py
+++ b/tests/unit/test_warehouse_transforms.py
@@ -1,0 +1,223 @@
+"""Tests for dataenginex.warehouse.transforms — Transform classes and TransformPipeline."""
+
+from __future__ import annotations
+
+import pytest
+
+from dataenginex.warehouse.transforms import (
+    AddTimestampTransform,
+    CastTypesTransform,
+    DropNullsTransform,
+    FilterTransform,
+    RenameFieldsTransform,
+    Transform,
+    TransformPipeline,
+    TransformResult,
+)
+
+# ── TransformResult ───────────────────────────────────────────────────────────
+
+
+class TestTransformResult:
+    def test_success_rate_all_pass(self) -> None:
+        r = TransformResult(input_count=10, output_count=10)
+        assert r.success_rate >= 1.0  # 10/10
+
+    def test_success_rate_partial(self) -> None:
+        import math
+
+        r = TransformResult(input_count=10, output_count=7, dropped_count=3)
+        assert math.isclose(r.success_rate, 0.7)
+
+    def test_success_rate_zero_processed(self) -> None:
+        r = TransformResult(input_count=0, output_count=0)
+        assert not r.success_rate  # 0.0 is falsy
+
+    def test_duration_and_records(self) -> None:
+        import math
+
+        r = TransformResult(input_count=5, output_count=4, dropped_count=1, duration_ms=12.5)
+        assert r.dropped_count == 1
+        assert math.isclose(r.duration_ms, 12.5)
+
+
+# ── Transform (ABC) ───────────────────────────────────────────────────────────
+
+
+class TestTransformABC:
+    def test_cannot_instantiate(self) -> None:
+        with pytest.raises(TypeError):
+            Transform("t")  # type: ignore[abstract]
+
+    def test_name_and_description(self) -> None:
+        class MyT(Transform):
+            def apply(self, r):
+                return r
+
+        t = MyT("my-transform", "does things")
+        assert t.name == "my-transform"
+        assert t.description == "does things"
+
+
+# ── RenameFieldsTransform ─────────────────────────────────────────────────────
+
+
+class TestRenameFieldsTransform:
+    def test_renames_fields(self) -> None:
+        t = RenameFieldsTransform({"old_name": "new_name"})
+        result = t.apply({"old_name": "value", "other": 1})
+        assert "new_name" in result
+        assert "old_name" not in result
+        assert result["other"] == 1
+
+    def test_missing_field_ignored(self) -> None:
+        t = RenameFieldsTransform({"missing": "renamed"})
+        record = {"kept": "x"}
+        result = t.apply(record)
+        assert result == record
+
+    def test_empty_mapping(self) -> None:
+        t = RenameFieldsTransform({})
+        record = {"a": 1}
+        assert t.apply(record) == record
+
+
+# ── DropNullsTransform ────────────────────────────────────────────────────────
+
+
+class TestDropNullsTransform:
+    def test_passes_complete_record(self) -> None:
+        t = DropNullsTransform(required_fields=["id", "name"])
+        assert t.apply({"id": 1, "name": "alice"}) is not None
+
+    def test_drops_record_with_null(self) -> None:
+        t = DropNullsTransform(required_fields=["id"])
+        assert t.apply({"id": None}) is None
+
+    def test_drops_record_with_missing_field(self) -> None:
+        t = DropNullsTransform(required_fields=["id"])
+        assert t.apply({"name": "x"}) is None
+
+    def test_empty_required_fields(self) -> None:
+        t = DropNullsTransform(required_fields=[])
+        assert t.apply({"anything": None}) is not None
+
+
+# ── CastTypesTransform ────────────────────────────────────────────────────────
+
+
+class TestCastTypesTransform:
+    def test_cast_to_int(self) -> None:
+        t = CastTypesTransform(type_map={"age": "int"})
+        result = t.apply({"age": "25"})
+        assert result["age"] == 25
+        assert isinstance(result["age"], int)
+
+    def test_cast_to_float(self) -> None:
+        t = CastTypesTransform(type_map={"score": "float"})
+        result = t.apply({"score": "3.14"})
+        assert isinstance(result["score"], float)
+
+    def test_cast_to_str(self) -> None:
+        t = CastTypesTransform(type_map={"code": "str"})
+        result = t.apply({"code": 42})
+        assert result["code"] == "42"
+
+    def test_missing_field_unchanged(self) -> None:
+        t = CastTypesTransform(type_map={"x": "int"})
+        record = {"y": "hello"}
+        result = t.apply(record)
+        assert "x" not in result
+
+    def test_cast_error_keeps_original(self) -> None:
+        t = CastTypesTransform(type_map={"age": "int"})
+        result = t.apply({"age": "not_an_int"})
+        assert result["age"] == "not_an_int"
+
+
+# ── AddTimestampTransform ─────────────────────────────────────────────────────
+
+
+class TestAddTimestampTransform:
+    def test_adds_timestamp_field(self) -> None:
+        t = AddTimestampTransform()
+        result = t.apply({"id": 1})
+        assert "processed_at" in result
+
+    def test_custom_field_name(self) -> None:
+        t = AddTimestampTransform(field_name="ingested_at")
+        result = t.apply({"id": 1})
+        assert "ingested_at" in result
+
+    def test_timestamp_is_string(self) -> None:
+        t = AddTimestampTransform()
+        result = t.apply({})
+        assert isinstance(result["processed_at"], str)
+
+
+# ── FilterTransform ───────────────────────────────────────────────────────────
+
+
+class TestFilterTransform:
+    def test_passes_when_predicate_true(self) -> None:
+        t = FilterTransform("age_filter", predicate=lambda r: r.get("age", 0) >= 18)
+        assert t.apply({"age": 25}) is not None
+
+    def test_drops_when_predicate_false(self) -> None:
+        t = FilterTransform("age_filter", predicate=lambda r: r.get("age", 0) >= 18)
+        assert t.apply({"age": 10}) is None
+
+    def test_custom_name(self) -> None:
+        t = FilterTransform("my_filter", predicate=lambda _: True)
+        assert t.name == "my_filter"
+
+
+# ── TransformPipeline ─────────────────────────────────────────────────────────
+
+
+class TestTransformPipeline:
+    def test_empty_pipeline(self) -> None:
+        p = TransformPipeline(name="empty")
+        result = p.run([{"id": 1}])
+        assert result.input_count == 1
+        assert result.output_count == 1
+
+    def test_single_transform(self) -> None:
+        p = TransformPipeline(name="rename")
+        p.add(RenameFieldsTransform({"old": "new"}))
+        records = [{"old": "val"}, {"other": "x"}]
+        result = p.run(records)
+        assert result.input_count == 2
+
+    def test_drop_nulls_removes_records(self) -> None:
+        p = TransformPipeline(name="filter")
+        p.add(DropNullsTransform(required_fields=["id"]))
+        records = [{"id": 1}, {"id": None}, {"id": 3}]
+        result = p.run(records)
+        assert result.output_count == 2
+        assert result.dropped_count == 1
+
+    def test_chain_transforms(self) -> None:
+        p = TransformPipeline(name="chain")
+        p.add(RenameFieldsTransform({"raw_age": "age"}))
+        p.add(CastTypesTransform({"age": "int"}))
+        p.add(FilterTransform("adult", predicate=lambda r: r.get("age", 0) >= 18))
+        records = [{"raw_age": "25"}, {"raw_age": "10"}, {"raw_age": "30"}]
+        result = p.run(records)
+        assert result.output_count == 2
+
+    def test_empty_input(self) -> None:
+        p = TransformPipeline(name="empty_input")
+        p.add(DropNullsTransform(["id"]))
+        result = p.run([])
+        assert result.input_count == 0
+        assert result.output_count == 0
+
+    def test_fluent_add(self) -> None:
+        p = TransformPipeline(name="fluent")
+        ret = p.add(DropNullsTransform(["id"]))
+        assert ret is p  # fluent API returns self
+
+    def test_pipeline_name(self) -> None:
+        p = TransformPipeline(name="my_pipeline")
+        assert p.name == "my_pipeline"

--- a/uv.lock
+++ b/uv.lock
@@ -27,7 +27,7 @@ wheels = [
 
 [[package]]
 name = "aiohttp"
-version = "3.13.5"
+version = "3.14.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiohappyeyeballs" },
@@ -38,59 +38,72 @@ dependencies = [
     { name = "propcache" },
     { name = "yarl" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/77/9a/152096d4808df8e4268befa55fba462f440f14beab85e8ad9bf990516918/aiohttp-3.13.5.tar.gz", hash = "sha256:9d98cc980ecc96be6eb4c1994ce35d28d8b1f5e5208a23b421187d1209dbb7d1", size = 7858271, upload-time = "2026-03-31T22:01:03.343Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ee/ab/93ce242f899b68c51b0578c027aafa791ab3614cb9345fa5d37b5f5c8e3e/aiohttp-3.14.0.tar.gz", hash = "sha256:2882de819734c715fd1b9c11c97e09fa020d14438203d1d354d8ed1702791c9b", size = 7940674, upload-time = "2026-06-01T19:41:02.763Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/78/e9/d76bf503005709e390122d34e15256b88f7008e246c4bdbe915cd4f1adce/aiohttp-3.13.5-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:a5029cc80718bbd545123cd8fe5d15025eccaaaace5d0eeec6bd556ad6163d61", size = 742930, upload-time = "2026-03-31T21:58:13.155Z" },
-    { url = "https://files.pythonhosted.org/packages/57/00/4b7b70223deaebd9bb85984d01a764b0d7bd6526fcdc73cca83bcbe7243e/aiohttp-3.13.5-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:4bb6bf5811620003614076bdc807ef3b5e38244f9d25ca5fe888eaccea2a9832", size = 496927, upload-time = "2026-03-31T21:58:15.073Z" },
-    { url = "https://files.pythonhosted.org/packages/9c/f5/0fb20fb49f8efdcdce6cd8127604ad2c503e754a8f139f5e02b01626523f/aiohttp-3.13.5-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:a84792f8631bf5a94e52d9cc881c0b824ab42717165a5579c760b830d9392ac9", size = 497141, upload-time = "2026-03-31T21:58:17.009Z" },
-    { url = "https://files.pythonhosted.org/packages/3b/86/b7c870053e36a94e8951b803cb5b909bfbc9b90ca941527f5fcafbf6b0fa/aiohttp-3.13.5-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:57653eac22c6a4c13eb22ecf4d673d64a12f266e72785ab1c8b8e5940d0e8090", size = 1732476, upload-time = "2026-03-31T21:58:18.925Z" },
-    { url = "https://files.pythonhosted.org/packages/b5/e5/4e161f84f98d80c03a238671b4136e6530453d65262867d989bbe78244d0/aiohttp-3.13.5-cp313-cp313-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:e5e5f7debc7a57af53fdf5c5009f9391d9f4c12867049d509bf7bb164a6e295b", size = 1706507, upload-time = "2026-03-31T21:58:21.094Z" },
-    { url = "https://files.pythonhosted.org/packages/d4/56/ea11a9f01518bd5a2a2fcee869d248c4b8a0cfa0bb13401574fa31adf4d4/aiohttp-3.13.5-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:c719f65bebcdf6716f10e9eff80d27567f7892d8988c06de12bbbd39307c6e3a", size = 1773465, upload-time = "2026-03-31T21:58:23.159Z" },
-    { url = "https://files.pythonhosted.org/packages/eb/40/333ca27fb74b0383f17c90570c748f7582501507307350a79d9f9f3c6eb1/aiohttp-3.13.5-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:d97f93fdae594d886c5a866636397e2bcab146fd7a132fd6bb9ce182224452f8", size = 1873523, upload-time = "2026-03-31T21:58:25.59Z" },
-    { url = "https://files.pythonhosted.org/packages/f0/d2/e2f77eef1acb7111405433c707dc735e63f67a56e176e72e9e7a2cd3f493/aiohttp-3.13.5-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:3df334e39d4c2f899a914f1dba283c1aadc311790733f705182998c6f7cae665", size = 1754113, upload-time = "2026-03-31T21:58:27.624Z" },
-    { url = "https://files.pythonhosted.org/packages/fb/56/3f653d7f53c89669301ec9e42c95233e2a0c0a6dd051269e6e678db4fdb0/aiohttp-3.13.5-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:fe6970addfea9e5e081401bcbadf865d2b6da045472f58af08427e108d618540", size = 1562351, upload-time = "2026-03-31T21:58:29.918Z" },
-    { url = "https://files.pythonhosted.org/packages/ec/a6/9b3e91eb8ae791cce4ee736da02211c85c6f835f1bdfac0594a8a3b7018c/aiohttp-3.13.5-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:7becdf835feff2f4f335d7477f121af787e3504b48b449ff737afb35869ba7bb", size = 1693205, upload-time = "2026-03-31T21:58:32.214Z" },
-    { url = "https://files.pythonhosted.org/packages/98/fc/bfb437a99a2fcebd6b6eaec609571954de2ed424f01c352f4b5504371dd3/aiohttp-3.13.5-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:676e5651705ad5d8a70aeb8eb6936c436d8ebbd56e63436cb7dd9bb36d2a9a46", size = 1730618, upload-time = "2026-03-31T21:58:34.728Z" },
-    { url = "https://files.pythonhosted.org/packages/e4/b6/c8534862126191a034f68153194c389addc285a0f1347d85096d349bbc15/aiohttp-3.13.5-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:9b16c653d38eb1a611cc898c41e76859ca27f119d25b53c12875fd0474ae31a8", size = 1745185, upload-time = "2026-03-31T21:58:36.909Z" },
-    { url = "https://files.pythonhosted.org/packages/0b/93/4ca8ee2ef5236e2707e0fd5fecb10ce214aee1ff4ab307af9c558bda3b37/aiohttp-3.13.5-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:999802d5fa0389f58decd24b537c54aa63c01c3219ce17d1214cbda3c2b22d2d", size = 1557311, upload-time = "2026-03-31T21:58:39.38Z" },
-    { url = "https://files.pythonhosted.org/packages/57/ae/76177b15f18c5f5d094f19901d284025db28eccc5ae374d1d254181d33f4/aiohttp-3.13.5-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:ec707059ee75732b1ba130ed5f9580fe10ff75180c812bc267ded039db5128c6", size = 1773147, upload-time = "2026-03-31T21:58:41.476Z" },
-    { url = "https://files.pythonhosted.org/packages/01/a4/62f05a0a98d88af59d93b7fcac564e5f18f513cb7471696ac286db970d6a/aiohttp-3.13.5-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:2d6d44a5b48132053c2f6cd5c8cb14bc67e99a63594e336b0f2af81e94d5530c", size = 1730356, upload-time = "2026-03-31T21:58:44.049Z" },
-    { url = "https://files.pythonhosted.org/packages/e4/85/fc8601f59dfa8c9523808281f2da571f8b4699685f9809a228adcc90838d/aiohttp-3.13.5-cp313-cp313-win32.whl", hash = "sha256:329f292ed14d38a6c4c435e465f48bebb47479fd676a0411936cc371643225cc", size = 432637, upload-time = "2026-03-31T21:58:46.167Z" },
-    { url = "https://files.pythonhosted.org/packages/c0/1b/ac685a8882896acf0f6b31d689e3792199cfe7aba37969fa91da63a7fa27/aiohttp-3.13.5-cp313-cp313-win_amd64.whl", hash = "sha256:69f571de7500e0557801c0b51f4780482c0ec5fe2ac851af5a92cfce1af1cb83", size = 458896, upload-time = "2026-03-31T21:58:48.119Z" },
-    { url = "https://files.pythonhosted.org/packages/5d/ce/46572759afc859e867a5bc8ec3487315869013f59281ce61764f76d879de/aiohttp-3.13.5-cp314-cp314-macosx_10_13_universal2.whl", hash = "sha256:eb4639f32fd4a9904ab8fb45bf3383ba71137f3d9d4ba25b3b3f3109977c5b8c", size = 745721, upload-time = "2026-03-31T21:58:50.229Z" },
-    { url = "https://files.pythonhosted.org/packages/13/fe/8a2efd7626dbe6049b2ef8ace18ffda8a4dfcbe1bcff3ac30c0c7575c20b/aiohttp-3.13.5-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:7e5dc4311bd5ac493886c63cbf76ab579dbe4641268e7c74e48e774c74b6f2be", size = 497663, upload-time = "2026-03-31T21:58:52.232Z" },
-    { url = "https://files.pythonhosted.org/packages/9b/91/cc8cc78a111826c54743d88651e1687008133c37e5ee615fee9b57990fac/aiohttp-3.13.5-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:756c3c304d394977519824449600adaf2be0ccee76d206ee339c5e76b70ded25", size = 499094, upload-time = "2026-03-31T21:58:54.566Z" },
-    { url = "https://files.pythonhosted.org/packages/0a/33/a8362cb15cf16a3af7e86ed11962d5cd7d59b449202dc576cdc731310bde/aiohttp-3.13.5-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ecc26751323224cf8186efcf7fbcbc30f4e1d8c7970659daf25ad995e4032a56", size = 1726701, upload-time = "2026-03-31T21:58:56.864Z" },
-    { url = "https://files.pythonhosted.org/packages/45/0c/c091ac5c3a17114bd76cbf85d674650969ddf93387876cf67f754204bd77/aiohttp-3.13.5-cp314-cp314-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:10a75acfcf794edf9d8db50e5a7ec5fc818b2a8d3f591ce93bc7b1210df016d2", size = 1683360, upload-time = "2026-03-31T21:58:59.072Z" },
-    { url = "https://files.pythonhosted.org/packages/23/73/bcee1c2b79bc275e964d1446c55c54441a461938e70267c86afaae6fba27/aiohttp-3.13.5-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:0f7a18f258d124cd678c5fe072fe4432a4d5232b0657fca7c1847f599233c83a", size = 1773023, upload-time = "2026-03-31T21:59:01.776Z" },
-    { url = "https://files.pythonhosted.org/packages/c7/ef/720e639df03004fee2d869f771799d8c23046dec47d5b81e396c7cda583a/aiohttp-3.13.5-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:df6104c009713d3a89621096f3e3e88cc323fd269dbd7c20afe18535094320be", size = 1853795, upload-time = "2026-03-31T21:59:04.568Z" },
-    { url = "https://files.pythonhosted.org/packages/bd/c9/989f4034fb46841208de7aeeac2c6d8300745ab4f28c42f629ba77c2d916/aiohttp-3.13.5-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:241a94f7de7c0c3b616627aaad530fe2cb620084a8b144d3be7b6ecfe95bae3b", size = 1730405, upload-time = "2026-03-31T21:59:07.221Z" },
-    { url = "https://files.pythonhosted.org/packages/ce/75/ee1fd286ca7dc599d824b5651dad7b3be7ff8d9a7e7b3fe9820d9180f7db/aiohttp-3.13.5-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:c974fb66180e58709b6fc402846f13791240d180b74de81d23913abe48e96d94", size = 1558082, upload-time = "2026-03-31T21:59:09.484Z" },
-    { url = "https://files.pythonhosted.org/packages/c3/20/1e9e6650dfc436340116b7aa89ff8cb2bbdf0abc11dfaceaad8f74273a10/aiohttp-3.13.5-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:6e27ea05d184afac78aabbac667450c75e54e35f62238d44463131bd3f96753d", size = 1692346, upload-time = "2026-03-31T21:59:12.068Z" },
-    { url = "https://files.pythonhosted.org/packages/d8/40/8ebc6658d48ea630ac7903912fe0dd4e262f0e16825aa4c833c56c9f1f56/aiohttp-3.13.5-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:a79a6d399cef33a11b6f004c67bb07741d91f2be01b8d712d52c75711b1e07c7", size = 1698891, upload-time = "2026-03-31T21:59:14.552Z" },
-    { url = "https://files.pythonhosted.org/packages/d8/78/ea0ae5ec8ba7a5c10bdd6e318f1ba5e76fcde17db8275188772afc7917a4/aiohttp-3.13.5-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:c632ce9c0b534fbe25b52c974515ed674937c5b99f549a92127c85f771a78772", size = 1742113, upload-time = "2026-03-31T21:59:17.068Z" },
-    { url = "https://files.pythonhosted.org/packages/8a/66/9d308ed71e3f2491be1acb8769d96c6f0c47d92099f3bc9119cada27b357/aiohttp-3.13.5-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:fceedde51fbd67ee2bcc8c0b33d0126cc8b51ef3bbde2f86662bd6d5a6f10ec5", size = 1553088, upload-time = "2026-03-31T21:59:19.541Z" },
-    { url = "https://files.pythonhosted.org/packages/da/a6/6cc25ed8dfc6e00c90f5c6d126a98e2cf28957ad06fa1036bd34b6f24a2c/aiohttp-3.13.5-cp314-cp314-musllinux_1_2_s390x.whl", hash = "sha256:f92995dfec9420bb69ae629abf422e516923ba79ba4403bc750d94fb4a6c68c1", size = 1757976, upload-time = "2026-03-31T21:59:22.311Z" },
-    { url = "https://files.pythonhosted.org/packages/c1/2b/cce5b0ffe0de99c83e5e36d8f828e4161e415660a9f3e58339d07cce3006/aiohttp-3.13.5-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:20ae0ff08b1f2c8788d6fb85afcb798654ae6ba0b747575f8562de738078457b", size = 1712444, upload-time = "2026-03-31T21:59:24.635Z" },
-    { url = "https://files.pythonhosted.org/packages/6c/cf/9e1795b4160c58d29421eafd1a69c6ce351e2f7c8d3c6b7e4ca44aea1a5b/aiohttp-3.13.5-cp314-cp314-win32.whl", hash = "sha256:b20df693de16f42b2472a9c485e1c948ee55524786a0a34345511afdd22246f3", size = 438128, upload-time = "2026-03-31T21:59:27.291Z" },
-    { url = "https://files.pythonhosted.org/packages/22/4d/eaedff67fc805aeba4ba746aec891b4b24cebb1a7d078084b6300f79d063/aiohttp-3.13.5-cp314-cp314-win_amd64.whl", hash = "sha256:f85c6f327bf0b8c29da7d93b1cabb6363fb5e4e160a32fa241ed2dce21b73162", size = 464029, upload-time = "2026-03-31T21:59:29.429Z" },
-    { url = "https://files.pythonhosted.org/packages/79/11/c27d9332ee20d68dd164dc12a6ecdef2e2e35ecc97ed6cf0d2442844624b/aiohttp-3.13.5-cp314-cp314t-macosx_10_13_universal2.whl", hash = "sha256:1efb06900858bb618ff5cee184ae2de5828896c448403d51fb633f09e109be0a", size = 778758, upload-time = "2026-03-31T21:59:31.547Z" },
-    { url = "https://files.pythonhosted.org/packages/04/fb/377aead2e0a3ba5f09b7624f702a964bdf4f08b5b6728a9799830c80041e/aiohttp-3.13.5-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:fee86b7c4bd29bdaf0d53d14739b08a106fdda809ca5fe032a15f52fae5fe254", size = 512883, upload-time = "2026-03-31T21:59:34.098Z" },
-    { url = "https://files.pythonhosted.org/packages/bb/a6/aa109a33671f7a5d3bd78b46da9d852797c5e665bfda7d6b373f56bff2ec/aiohttp-3.13.5-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:20058e23909b9e65f9da62b396b77dfa95965cbe840f8def6e572538b1d32e36", size = 516668, upload-time = "2026-03-31T21:59:36.497Z" },
-    { url = "https://files.pythonhosted.org/packages/79/b3/ca078f9f2fa9563c36fb8ef89053ea2bb146d6f792c5104574d49d8acb63/aiohttp-3.13.5-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8cf20a8d6868cb15a73cab329ffc07291ba8c22b1b88176026106ae39aa6df0f", size = 1883461, upload-time = "2026-03-31T21:59:38.723Z" },
-    { url = "https://files.pythonhosted.org/packages/b7/e3/a7ad633ca1ca497b852233a3cce6906a56c3225fb6d9217b5e5e60b7419d/aiohttp-3.13.5-cp314-cp314t-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:330f5da04c987f1d5bdb8ae189137c77139f36bd1cb23779ca1a354a4b027800", size = 1747661, upload-time = "2026-03-31T21:59:41.187Z" },
-    { url = "https://files.pythonhosted.org/packages/33/b9/cd6fe579bed34a906d3d783fe60f2fa297ef55b27bb4538438ee49d4dc41/aiohttp-3.13.5-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:6f1cbf0c7926d315c3c26c2da41fd2b5d2fe01ac0e157b78caefc51a782196cf", size = 1863800, upload-time = "2026-03-31T21:59:43.84Z" },
-    { url = "https://files.pythonhosted.org/packages/c0/3f/2c1e2f5144cefa889c8afd5cf431994c32f3b29da9961698ff4e3811b79a/aiohttp-3.13.5-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:53fc049ed6390d05423ba33103ded7281fe897cf97878f369a527070bd95795b", size = 1958382, upload-time = "2026-03-31T21:59:46.187Z" },
-    { url = "https://files.pythonhosted.org/packages/66/1d/f31ec3f1013723b3babe3609e7f119c2c2fb6ef33da90061a705ef3e1bc8/aiohttp-3.13.5-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:898703aa2667e3c5ca4c54ca36cd73f58b7a38ef87a5606414799ebce4d3fd3a", size = 1803724, upload-time = "2026-03-31T21:59:48.656Z" },
-    { url = "https://files.pythonhosted.org/packages/0e/b4/57712dfc6f1542f067daa81eb61da282fab3e6f1966fca25db06c4fc62d5/aiohttp-3.13.5-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:0494a01ca9584eea1e5fbd6d748e61ecff218c51b576ee1999c23db7066417d8", size = 1640027, upload-time = "2026-03-31T21:59:51.284Z" },
-    { url = "https://files.pythonhosted.org/packages/25/3c/734c878fb43ec083d8e31bf029daae1beafeae582d1b35da234739e82ee7/aiohttp-3.13.5-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:6cf81fe010b8c17b09495cbd15c1d35afbc8fb405c0c9cf4738e5ae3af1d65be", size = 1806644, upload-time = "2026-03-31T21:59:53.753Z" },
-    { url = "https://files.pythonhosted.org/packages/20/a5/f671e5cbec1c21d044ff3078223f949748f3a7f86b14e34a365d74a5d21f/aiohttp-3.13.5-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:c564dd5f09ddc9d8f2c2d0a301cd30a79a2cc1b46dd1a73bef8f0038863d016b", size = 1791630, upload-time = "2026-03-31T21:59:56.239Z" },
-    { url = "https://files.pythonhosted.org/packages/0b/63/fb8d0ad63a0b8a99be97deac8c04dacf0785721c158bdf23d679a87aa99e/aiohttp-3.13.5-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:2994be9f6e51046c4f864598fd9abeb4fba6e88f0b2152422c9666dcd4aea9c6", size = 1809403, upload-time = "2026-03-31T21:59:59.103Z" },
-    { url = "https://files.pythonhosted.org/packages/59/0c/bfed7f30662fcf12206481c2aac57dedee43fe1c49275e85b3a1e1742294/aiohttp-3.13.5-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:157826e2fa245d2ef46c83ea8a5faf77ca19355d278d425c29fda0beb3318037", size = 1634924, upload-time = "2026-03-31T22:00:02.116Z" },
-    { url = "https://files.pythonhosted.org/packages/17/d6/fd518d668a09fd5a3319ae5e984d4d80b9a4b3df4e21c52f02251ef5a32e/aiohttp-3.13.5-cp314-cp314t-musllinux_1_2_s390x.whl", hash = "sha256:a8aca50daa9493e9e13c0f566201a9006f080e7c50e5e90d0b06f53146a54500", size = 1836119, upload-time = "2026-03-31T22:00:04.756Z" },
-    { url = "https://files.pythonhosted.org/packages/78/b7/15fb7a9d52e112a25b621c67b69c167805cb1f2ab8f1708a5c490d1b52fe/aiohttp-3.13.5-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:3b13560160d07e047a93f23aaa30718606493036253d5430887514715b67c9d9", size = 1772072, upload-time = "2026-03-31T22:00:07.494Z" },
-    { url = "https://files.pythonhosted.org/packages/7e/df/57ba7f0c4a553fc2bd8b6321df236870ec6fd64a2a473a8a13d4f733214e/aiohttp-3.13.5-cp314-cp314t-win32.whl", hash = "sha256:9a0f4474b6ea6818b41f82172d799e4b3d29e22c2c520ce4357856fced9af2f8", size = 471819, upload-time = "2026-03-31T22:00:10.277Z" },
-    { url = "https://files.pythonhosted.org/packages/62/29/2f8418269e46454a26171bfdd6a055d74febf32234e474930f2f60a17145/aiohttp-3.13.5-cp314-cp314t-win_amd64.whl", hash = "sha256:18a2f6c1182c51baa1d28d68fea51513cb2a76612f038853c0ad3c145423d3d9", size = 505441, upload-time = "2026-03-31T22:00:12.791Z" },
+    { url = "https://files.pythonhosted.org/packages/21/61/d11f7d9a3144bffe825247d6367cd93053666da50b94707c9129c78868d5/aiohttp-3.14.0-cp313-cp313-android_21_arm64_v8a.whl", hash = "sha256:25400d710641a8040bf022a8a99f579e581ffa1c5bd42c33255d7d6f3957c127", size = 502399, upload-time = "2026-06-01T19:38:25.955Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/9b/a7e317625d36356844f8bb022cabd305b541f968856cc3c2e0b58e53ee6e/aiohttp-3.14.0-cp313-cp313-android_21_x86_64.whl", hash = "sha256:c5492b9929826e07cc3fcb9739ae87aab05dff6b5e67a9b73fd1700c6d008981", size = 510068, upload-time = "2026-06-01T19:38:27.828Z" },
+    { url = "https://files.pythonhosted.org/packages/11/41/cc2d2cfbfbdc3126ba258f3cd27d1ac8a33492ae3c35a4583ee21f0ba7f1/aiohttp-3.14.0-cp313-cp313-ios_13_0_arm64_iphoneos.whl", hash = "sha256:3366751d68d237c621264233a32f3078bbc21b7904ab90a77e03d21390c742c6", size = 481670, upload-time = "2026-06-01T19:38:29.836Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/07/381f4023c3b08cb616e520f566d8c58957abad54e56441d41fe67cfb0195/aiohttp-3.14.0-cp313-cp313-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:57ea07d28695a7a40304d42251892a8df765e5588c10ee32afeddcd5df33c0a2", size = 487591, upload-time = "2026-06-01T19:38:31.704Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/4d/4506fdb7a022bdf70011a3bbb4ca00c5c570026ef6a3c5bd7bc70c39089c/aiohttp-3.14.0-cp313-cp313-ios_13_0_x86_64_iphonesimulator.whl", hash = "sha256:076cb014191ae2e65d949e1ad01f1dcfe33e32789b5172510f3e79c79fc04d50", size = 496503, upload-time = "2026-06-01T19:38:33.6Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/7d/c814111e04894a45d9e2defc94443879a6f118d9633d5fedfe6e2e8af5f0/aiohttp-3.14.0-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:2f3fc37054564dee64a855b5b092d87ec35dcddfaabf7dacb1c8a2b1f83dc0a9", size = 745870, upload-time = "2026-06-01T19:38:36.013Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/ee/80eee0efddfe187e7cd05027086b7ce1c0e492e82a4eda58f5c5543a44a0/aiohttp-3.14.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:8fcaef74d2ab0f607d7ff85a0d15e21bb5a258c4a58df1908396eb50d7f4ed3c", size = 505588, upload-time = "2026-06-01T19:38:38.282Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/f8/0f28f04eef75d52fc9c715dde7ce9c0abb810fd20cfeb0fea7afd2ab1e98/aiohttp-3.14.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:e4c01b0bfc6209590960e68eac083cd22d5d87c21f974dd6208cafa5d3542bc8", size = 504492, upload-time = "2026-06-01T19:38:40.611Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/db/44c755232085545065c94378dfce38641b1aee647f4939fcd32f5b32e719/aiohttp-3.14.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f12eb7896e81caf403a2b18c9406426f1207361e7239c057ab29c076d4257e83", size = 1752111, upload-time = "2026-06-01T19:38:42.682Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/6a/42e030a46743841414402a3b00cd3d78419055e86c66fb5822c14b5abfc6/aiohttp-3.14.0-cp313-cp313-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:6c79a044cacf360ec46738d863d2f41c9300d2a06ef4a7402ea0df306a350e61", size = 1729674, upload-time = "2026-06-01T19:38:44.79Z" },
+    { url = "https://files.pythonhosted.org/packages/34/26/3199beb415202e3108e7b83ecebe10914d806d33fb9860c3e4aa60a19be3/aiohttp-3.14.0-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:85e0675f47be4eff0636bf88c02140ea89168ae0df3ff1f3f464e9de9610d277", size = 1798808, upload-time = "2026-06-01T19:38:47.01Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/94/b9b6fcf0ee17c21d0d19fb8c22bf83ad18f82e702a9c3bd901a868f5e446/aiohttp-3.14.0-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:7b33e751cab03fdc960095b1e326cb5a03f5ee577d6ded59f3d1c100f8668882", size = 1891921, upload-time = "2026-06-01T19:38:49.233Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/a3/3800dbd095cb2bb165a7ea5d94d790914677e27f45638c7d80e3f34c8945/aiohttp-3.14.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:26d9224c6dd7f5c749aba4f61315a894601448b28d94d12f4dea0903e26d2096", size = 1777241, upload-time = "2026-06-01T19:38:52.04Z" },
+    { url = "https://files.pythonhosted.org/packages/21/2a/45be91ad1b860508557448d4cc2e165a2ee68dd865657b73bf66cc5a00fb/aiohttp-3.14.0-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:6281aecdf2732940f4fe06bd6adec5ae4d59b78b080b8e3a6b81467301010988", size = 1579554, upload-time = "2026-06-01T19:38:54.508Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/3d/dc94df99ed1511fdf28314f722643ed334112643cab00223577085e788c4/aiohttp-3.14.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:23e8314e7aed8576fbe33314d218bd81447a3adbc91dc36f1163bf583cd3084c", size = 1714864, upload-time = "2026-06-01T19:38:56.788Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/e4/1f1c8acbb3acd5c8f795473b92c9c3d44eb60a5692c6104256c8a1c83a0c/aiohttp-3.14.0-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:3b54fbff46127aeafdd764cecd0d99fa2f24a0e37ea5c18a7c3a4ac450df1db3", size = 1749803, upload-time = "2026-06-01T19:38:59.367Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/c8/c45ea6e7ed84cebba939b9c334498a045ba19d79c61b0110df5f21580de3/aiohttp-3.14.0-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:b27d89af91a555f58e08e4902dbcbc48862fd40095720ca705990476bd93b7ac", size = 1765023, upload-time = "2026-06-01T19:39:01.651Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/a1/a932941784432962fe390e1066823aaef64b4e5ac9fa595df57b5fe472a9/aiohttp-3.14.0-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:25d2326a4967bf705a9f9913a13005e93b6020ad8a9f6bd6bd78850d5171332e", size = 1571671, upload-time = "2026-06-01T19:39:04.044Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/01/e1280feac522597a4d46eb67a0cdfa053cfae263033030b761ab146f29fb/aiohttp-3.14.0-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:a1d209375c503472b3c0a340cdf3c55fcd82e84b46dda7caeaced59faba373ec", size = 1789904, upload-time = "2026-06-01T19:39:06.294Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/10/ab28818262f4d26bdb47ed5f1fc7999b69e2fc6e0370b02d0f49011f45ea/aiohttp-3.14.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:666c7c5036df57b693026398b69b41874a1931ac5b3485fd910e57bfac253869", size = 1754516, upload-time = "2026-06-01T19:39:08.788Z" },
+    { url = "https://files.pythonhosted.org/packages/af/cc/c122eabd7a1b7e0c9bbdd6be60e4715905b858399145d9df872bb94f1427/aiohttp-3.14.0-cp313-cp313-win32.whl", hash = "sha256:23f094a1ef64823fd35854ddf5c7a80a078162f37f9d2f7c6142b51a6affa456", size = 448656, upload-time = "2026-06-01T19:39:11.171Z" },
+    { url = "https://files.pythonhosted.org/packages/41/a5/bab07d79848a00eedd8ed979ccb302aaea3ac6eb9fa16bd0ed87135869b4/aiohttp-3.14.0-cp313-cp313-win_amd64.whl", hash = "sha256:e03abdaa17d553f17e1d1d06bb266b3970106c78051d06795723e748d8e49d11", size = 475803, upload-time = "2026-06-01T19:39:13.439Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/a0/f03ade8566c153666a3871afccbedf6d99911da006325e1fc6cf72a2de99/aiohttp-3.14.0-cp313-cp313-win_arm64.whl", hash = "sha256:acdb400538cf4769543548bb5d1eb23d39bed4f96554a6078cb728c7cb2c268b", size = 443889, upload-time = "2026-06-01T19:39:15.945Z" },
+    { url = "https://files.pythonhosted.org/packages/28/03/5f36ab196a88ba5e9648ae5643e6531e67a3a8c0e96f9c6510ff41540fec/aiohttp-3.14.0-cp314-cp314-android_24_arm64_v8a.whl", hash = "sha256:363ef9e91014e7891679bfb2ac0a7c6ea93435dbbfd10ecf41b9f06fcf506c5f", size = 503330, upload-time = "2026-06-01T19:39:18.195Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/ce/8b49ec2f30f68e02f314f4832186cd45e583360a5a386058be36855d23b6/aiohttp-3.14.0-cp314-cp314-android_24_x86_64.whl", hash = "sha256:884a4edbdad77be9d0ef36142c8b504351b170df0bf62b51e784fadabf311c42", size = 509822, upload-time = "2026-06-01T19:39:20.396Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/fe/6edbf5d39bf29322b6816365b17ed8ede4dace164a3aea1abcd30110eb78/aiohttp-3.14.0-cp314-cp314-ios_13_0_arm64_iphoneos.whl", hash = "sha256:70ea956f6cc4a37620966b56c2e205d88ca3e6d85ec063277e414b1035cddad3", size = 483329, upload-time = "2026-06-01T19:39:22.607Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/5a/fae531bdbc6456fb6241f46b7b81e4d8a0dd3fc09118a0055dc7141ac1ec/aiohttp-3.14.0-cp314-cp314-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:ea3b9806c89f61da22fddf1f12dd524fb368e5e28f1261fbdafe5c3cd8ce893b", size = 489502, upload-time = "2026-06-01T19:39:24.881Z" },
+    { url = "https://files.pythonhosted.org/packages/36/f4/48a7b0414db7fed77a03d5dde34508c026afd83510ab6bca08c313855776/aiohttp-3.14.0-cp314-cp314-ios_13_0_x86_64_iphonesimulator.whl", hash = "sha256:a071be341c2bd9b0188e62d173509f024e0a35b1c342c53c50f8daaeda8c3bd8", size = 497357, upload-time = "2026-06-01T19:39:27.197Z" },
+    { url = "https://files.pythonhosted.org/packages/75/75/e85a13a370acc007fca5feb1fd1b88ac2d8426e6dadd625479b7cadd55a3/aiohttp-3.14.0-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:198cfe61bf253b19da1fb3e0fa122249dc4f14c12709493fed8054aa0411cc76", size = 750898, upload-time = "2026-06-01T19:39:29.563Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/e4/3d637f800c724eff0e2bed64df72557444482366fd0a35b0cec0e6968f6c/aiohttp-3.14.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:9dc203d6ce6b9106d54e2a93f41dfdfebfbca2d99962ba503bfd3e5921a6549e", size = 506986, upload-time = "2026-06-01T19:39:31.872Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/df/35161f3598bf7501d2b2a805b41ab4f45a2e34150c421bcb4ef8c0d281a7/aiohttp-3.14.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:9e19d17ab02bf16832a2c8c0d55a486792c5b1645665652ee9531aebcc30cb72", size = 508033, upload-time = "2026-06-01T19:39:34.137Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/39/b36e5d3d31e850fb4691dd3e941684ac490a2559249f6fa634b6b0fdf020/aiohttp-3.14.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d925fba0c14d5b498a8028b0107beebdfd16c5d48d702ff54f879cb017aaaca3", size = 1746213, upload-time = "2026-06-01T19:39:36.654Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/28/24e1409e605a9aa5d84abe0e2acb365354b70ae56d40948101cabe3341ab/aiohttp-3.14.0-cp314-cp314-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:d33e61021222ce7f9792bcac870d6f58d8adfceda33ab857b01264f4560f2c5f", size = 1705862, upload-time = "2026-06-01T19:39:38.968Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/d0/e5eb3ff1daeaf644c7e36a957517672494122628e067c38b263fa04eda77/aiohttp-3.14.0-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:44eca38755d0105bb32f47d085f5dd449846a449e1245fc105889e3279dcf8e3", size = 1798909, upload-time = "2026-06-01T19:39:41.334Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/ba/8943f906f0570342886ababb9a722a44e360f786a028c5e0b0e29e3f735b/aiohttp-3.14.0-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:f13087e06f68fea4941c21a0c541c00553aa16e4f8fd7bbe2b198df761e964d6", size = 1868892, upload-time = "2026-06-01T19:39:43.807Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/05/27df32c844b2156e1675a8d8ec22d963e3c8ba469ed7ceb1863320c7b521/aiohttp-3.14.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ff82be7f1ef73634cb77890a770743239bc3d487b848669be1c599889336dc0a", size = 1751659, upload-time = "2026-06-01T19:39:46.398Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/62/da182e5910ab912b2e88aa919b61a16046a37a95714a5795b02eb57b2d18/aiohttp-3.14.0-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:a150c0875ac8fd87f1c398650841308a30d65facf7416b12dbdb9cfdcbe5a48c", size = 1578775, upload-time = "2026-06-01T19:39:48.902Z" },
+    { url = "https://files.pythonhosted.org/packages/66/e3/53c67097e8a5ce98625e91e3fa7f43c9c6940de680345d03b3509a72a078/aiohttp-3.14.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:edc01ea4e1ec5a1649a28866262bf24195889ff7b27bdd947029a6086741de9b", size = 1710090, upload-time = "2026-06-01T19:39:51.392Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/55/0e2732ca598c7a4dfe8a775662376d0ca2977cb1030e48386d4da5d9a456/aiohttp-3.14.0-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:540632bf882ff8fc88f2e1697be0761578e89e0d79fb4a8a6d65dc5da7e729d4", size = 1715016, upload-time = "2026-06-01T19:39:53.807Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/96/f0b73730798c9ca525afc30b39f1f81bbe24e245d9654c54d3b39d63212d/aiohttp-3.14.0-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:860a86bc2c80237f5dff52edcf427e10a8d8352271fd84845429a3e60199e02c", size = 1763810, upload-time = "2026-06-01T19:39:56.31Z" },
+    { url = "https://files.pythonhosted.org/packages/71/cc/11acb6c4518f448323405a7312b6f255d0f974a34373ad1db7633c4aadc8/aiohttp-3.14.0-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:5cbd50e6a50d6b99283a826b18cbdebf65b0797689a7535cb0e9dd37be0f63c3", size = 1573064, upload-time = "2026-06-01T19:39:58.718Z" },
+    { url = "https://files.pythonhosted.org/packages/de/2d/28c31dde0a7dc98c0ee7d0da2ddcec3f7688c4fc131e5989e278d0c03c0a/aiohttp-3.14.0-cp314-cp314-musllinux_1_2_s390x.whl", hash = "sha256:20144819e99db593e22bbd2f3f2691a5e149f879142d6b8670254708853ff4fb", size = 1775765, upload-time = "2026-06-01T19:40:01.195Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/69/155c4ef3aec96417d47024800472b33b16c5d8a665371dcd044c2afdf25d/aiohttp-3.14.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:26b6d79aa54cb4ed50cc7d41ed14e99e0f1fc8e7c2d42f2e05b37aea897b2b52", size = 1733716, upload-time = "2026-06-01T19:40:03.631Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/44/6126116fd8a316b712bb615660b855c78466bb67ba1bb1742427eafcf7ac/aiohttp-3.14.0-cp314-cp314-win32.whl", hash = "sha256:106ed074a856f3e21d186b8579e2c8afb6da598e267cdaab01059e13db2fc44d", size = 453684, upload-time = "2026-06-01T19:40:06.277Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/d7/eff4c58a88c5cac5e38b55f44fb8a6d3929c3cbd77356e383e094d3220bd/aiohttp-3.14.0-cp314-cp314-win_amd64.whl", hash = "sha256:4f770846edae8f00ecc57af825bce811f787f87a7dcf0e90d191790efe5b31f7", size = 481758, upload-time = "2026-06-01T19:40:08.653Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/ed/17b5bd9fbcb46e688f02e572f517754a9a75831e7b54702f027761dc4fa5/aiohttp-3.14.0-cp314-cp314-win_arm64.whl", hash = "sha256:acf1581c4f21ed4b80a2dded504d87b055a071a84d5737ea966435f768275ac6", size = 450557, upload-time = "2026-06-01T19:40:11.03Z" },
+    { url = "https://files.pythonhosted.org/packages/12/34/6180103ce9aabc8ebff3f7bb55a1228ffe60f61042823031d9692cb7b101/aiohttp-3.14.0-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:6aa1a40f9cbb3da9f80714c5966b8946c21e6a2530d809b9498b33161e3c8733", size = 787878, upload-time = "2026-06-01T19:40:13.401Z" },
+    { url = "https://files.pythonhosted.org/packages/92/e9/08954a40e8b7baa3d8beadd2b074b186e9b1e9c8ddabc288678a6265de50/aiohttp-3.14.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:b62af5a8cc96a194eaa01a9ed7b34a3ffa58d3d8daaa1a0d7a749353ad12d228", size = 524400, upload-time = "2026-06-01T19:40:15.972Z" },
+    { url = "https://files.pythonhosted.org/packages/08/6a/b5965a634ac4d5ba99a463314cf4ab214ca073fcdc38a15e0294273701fc/aiohttp-3.14.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:6eb63b1417efaf7d1002a6ad034a40d44376afcc16508a57f8e74b49ad26a095", size = 527904, upload-time = "2026-06-01T19:40:18.28Z" },
+    { url = "https://files.pythonhosted.org/packages/06/b4/932bcdd850c354d9bcca30f360e475d7852e30413fbbd44b182782ed5432/aiohttp-3.14.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c20b9ad156a79eb97be5cf9e069eec01d2f0dc8472ffbd75299a8b2d4c2cbbde", size = 1912162, upload-time = "2026-06-01T19:40:20.825Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/85/ce79bab0310d2e3fd2d7bc7e44412abeff7c8338f8a21dd0f2f1714989e5/aiohttp-3.14.0-cp314-cp314t-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:40ae7b0642c25632c7eabc4a04754012691864d2a1b93becf7cddb76027b838a", size = 1778813, upload-time = "2026-06-01T19:40:23.726Z" },
+    { url = "https://files.pythonhosted.org/packages/05/54/ba62ac2d1bc87e010aad23751e383b8794e45d931df67677313a2da78823/aiohttp-3.14.0-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:95f5217e76a046b9f228a101717ef8d42b1eb3d9d196d15202db5bf41df88936", size = 1899969, upload-time = "2026-06-01T19:40:26.406Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/82/7cc7907725d83a19f31551334061e1ab8e108b1d7ac52632a2a844a4acb5/aiohttp-3.14.0-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:1a4a9f17e85b80878c176695c1998c790e83731d8271881e5d356488652a1f9e", size = 1991771, upload-time = "2026-06-01T19:40:29.061Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/1c/a57de71a4508c93a830b77c28af3d08cd97f606dedfc6b94275347744508/aiohttp-3.14.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:145262119b07d7f95abc1839add35ba2bfc84551d4b4660ca11542c0b215455b", size = 1868606, upload-time = "2026-06-01T19:40:31.843Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/ae/3839726cd49150a53ed340cc24ce5ba09d4c2117020ef9d45542bec5eb2f/aiohttp-3.14.0-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:49a33ded29b0b2fa7a367a02cf0fb89af602bb87542a16177ec8ce1c9c51d12a", size = 1665437, upload-time = "2026-06-01T19:40:35.01Z" },
+    { url = "https://files.pythonhosted.org/packages/35/1e/c237923232c7da7f0392ea25d89fc5e60c0e93f685f4ebca8e7bcdd5271c/aiohttp-3.14.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:2cc736a9c9fc2bc4dd71fd404815741b6573df27c3f985948ec4076989ac57de", size = 1834090, upload-time = "2026-06-01T19:40:37.733Z" },
+    { url = "https://files.pythonhosted.org/packages/98/02/a5a7a2524f92d3911761b405a7c067c751891942144adc13e2ad79611e39/aiohttp-3.14.0-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:b4141a3e5342ee3053a9cab54d25b64ed28289c1041e4c54b3d99839314d90ce", size = 1816907, upload-time = "2026-06-01T19:40:40.46Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/76/a8b9f0d09234d516af9f2d7dd715557f33b5da3b0b56ead41d1170e86e3c/aiohttp-3.14.0-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:e30871b2d58996cb81aac52d2b1d15ac05257131ef0f90f18c2115a380fbfe7c", size = 1840382, upload-time = "2026-06-01T19:40:43.48Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/8e/140e715a0a4bbc211979ea30ec8396ad2ed5bf90ab87d8058fc4668b1923/aiohttp-3.14.0-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:667b881d083ccae3900ea5a241e17e5007ca78844c53ed389bb63d48f729d9c7", size = 1659497, upload-time = "2026-06-01T19:40:46.265Z" },
+    { url = "https://files.pythonhosted.org/packages/10/c7/7ba5de8af9650b9767b063c675427b8685f43fa7ce563673a7bc3af60f08/aiohttp-3.14.0-cp314-cp314t-musllinux_1_2_s390x.whl", hash = "sha256:b584dfe615d151e9b8f0a8ecb3aee6147f2927ec5b95ba25fe621f5377510928", size = 1870829, upload-time = "2026-06-01T19:40:49.583Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/bc/2aaab2f85cadb26ea59c091fa2b8e370d625154b5c14b478f1b489d07551/aiohttp-3.14.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:6199707cc40e0e9cd39c36fbc97bec416c704e1d0ddce03412bb3b3e6a90ccd0", size = 1832281, upload-time = "2026-06-01T19:40:52.303Z" },
+    { url = "https://files.pythonhosted.org/packages/39/98/31b9ad9fbc01f0075ee7221002df5fd2d10b647f451ca5f30edc802d9dd6/aiohttp-3.14.0-cp314-cp314t-win32.whl", hash = "sha256:a8d93334d4961c9d566b1f046c81dee475b7c21eb730728d38237bfa70d1c8e6", size = 490597, upload-time = "2026-06-01T19:40:54.937Z" },
+    { url = "https://files.pythonhosted.org/packages/59/1f/299b21441c8de42ff70fddc7cfe65e92f810abcf740739a09b56f7835364/aiohttp-3.14.0-cp314-cp314t-win_amd64.whl", hash = "sha256:2d2ffe9b614f50f069068b3b52e73414e4107fc10b7efc939a76acff9251fdd2", size = 525789, upload-time = "2026-06-01T19:40:57.306Z" },
+    { url = "https://files.pythonhosted.org/packages/70/11/7f83fcba9ee05d4c54d61b3f8104da0d43a59adac44dd28effc0c9a10422/aiohttp-3.14.0-cp314-cp314t-win_arm64.whl", hash = "sha256:7a3fc4358e65826c515350f199c210de747cf669998211b1ee6c2e46de364b24", size = 467399, upload-time = "2026-06-01T19:40:59.993Z" },
 ]
 
 [[package]]
@@ -303,30 +316,30 @@ wheels = [
 
 [[package]]
 name = "boto3"
-version = "1.43.14"
+version = "1.43.21"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "botocore" },
     { name = "jmespath" },
     { name = "s3transfer" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/79/4b/616367e871ce3f1cb3e8545a97736b6331b9fb081497f2d44c5b2aa6959d/boto3-1.43.14.tar.gz", hash = "sha256:5c0a994b3182061ee101812e721100717a4d664f9f4ceaf4a86b6d032ce9fc2d", size = 113142, upload-time = "2026-05-22T19:28:47.861Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/1e/f2/0ef88b6584285002a8a8000e34340f56e82681ad2b8a76ea8bd3ecaa5cb9/boto3-1.43.21.tar.gz", hash = "sha256:6dfeb70bf4f9a3514b91c7199f475f71f939199d62f9c63cd555b033fb283f89", size = 113157, upload-time = "2026-06-03T07:09:23.263Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/cb/00/59cb9329c18e2d3aa23062ceaa87d065f2e81e7d2931df24d64e9a7815aa/boto3-1.43.14-py3-none-any.whl", hash = "sha256:574335744656cfed0b362a0a0467aaf2eb2bf15526edcd02d31d3c661f4b09e4", size = 140536, upload-time = "2026-05-22T19:28:46.49Z" },
+    { url = "https://files.pythonhosted.org/packages/01/ea/5352950cbee9d1e8392e5396ddbc6defc982414e2abc004b501139bce13c/boto3-1.43.21-py3-none-any.whl", hash = "sha256:8bb863b32dabe5baa4f2e3701778c259243ba117e4811a595411819958c4fb1b", size = 140534, upload-time = "2026-06-03T07:09:21.18Z" },
 ]
 
 [[package]]
 name = "botocore"
-version = "1.43.14"
+version = "1.43.21"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "jmespath" },
     { name = "python-dateutil" },
     { name = "urllib3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/78/3c/798d2f7deb118241930c7c6bcfb0b970d3f0245bf580700663199aeed2c3/botocore-1.43.14.tar.gz", hash = "sha256:b9e500737e43d2f147c9d4e23b54360335e77d4c0ba90a318f51b65e06cb8516", size = 15382604, upload-time = "2026-05-22T19:28:36.363Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/7b/97/d9d26cebf0a8533105e183d8438931c0b196e52484cd5bf00e8443ac1b2d/botocore-1.43.21.tar.gz", hash = "sha256:17604607efe28894e947401379e569cc8f0fe2d69337ece98bd0c82d1bcfaf92", size = 15451979, upload-time = "2026-06-03T07:09:11.489Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/27/7e/6e64821077cd2efc4aa51b7d638fb6d48e1c7c450201c529fbaf1de8bfd3/botocore-1.43.14-py3-none-any.whl", hash = "sha256:1f4a2a95ea78c10398e78431e98c1fe47adb54a7b10a32975144c1f541186658", size = 15061424, upload-time = "2026-05-22T19:28:32.682Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/c7/8c60049357e96d663980d66b98a44cb3626a7e5eaca66480b97826eb5379/botocore-1.43.21-py3-none-any.whl", hash = "sha256:f021ba3e844c36031106fc531ec90259ef005ba5d04f691df53bc4ecbd08f0dd", size = 15135303, upload-time = "2026-06-03T07:09:06.115Z" },
 ]
 
 [[package]]
@@ -572,71 +585,71 @@ wheels = [
 
 [[package]]
 name = "coverage"
-version = "7.14.0"
+version = "7.14.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/23/7f/d0720730a397a999ffc0fd3f5bebef347338e3a47b727da66fbb228e2ff2/coverage-7.14.0.tar.gz", hash = "sha256:057a6af2f160a85384cde4ab36f0d2777bae1057bae255f95413cdd382aa5c74", size = 919489, upload-time = "2026-05-10T18:02:31.397Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/54/fd/0ab2772530e946e1be1abd0bc09e647ec9b02e88f0867857601fefca8953/coverage-7.14.1.tar.gz", hash = "sha256:30c08f7d90415aa98b3c990385dea2939b0da55f38515e5b369b83655f8523be", size = 920132, upload-time = "2026-05-26T20:41:36.783Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/6b/76/b7c66ee3c66e1b0f9d894c8125983aa0c03fb2336f2fd16559f9c966157f/coverage-7.14.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:f2bbb8254370eb4c628ff3d6fa8a7f74ddc40565394d4f7ab791d1fe568e37ef", size = 219990, upload-time = "2026-05-10T18:00:38.887Z" },
-    { url = "https://files.pythonhosted.org/packages/b3/af/e567cbad5ba69c013a50146dfa886dc7193361fda77521f51274ff620e1b/coverage-7.14.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:23b81107f46d3f21d0cbce30664fcec0f5d9f585638a67081750f99738f6bf66", size = 220365, upload-time = "2026-05-10T18:00:40.864Z" },
-    { url = "https://files.pythonhosted.org/packages/44/6f/9ad575d505b4d805b254febc8a5b338a2efe278f8786e56ff1cb8413f9c3/coverage-7.14.0-cp313-cp313-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:22a7e06a5f11a757cdfe79018e9095f9f69ae283c5cd8123774c788deec8717b", size = 251363, upload-time = "2026-05-10T18:00:42.489Z" },
-    { url = "https://files.pythonhosted.org/packages/6f/5f/b5370068b2f57787454592ed7dcd1002f0f1703b7db1fa30f6a325a4ca6e/coverage-7.14.0-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:9d1aa57a1dc8e05bdc42e81c5d671d849577aeedf279f4c449d6d286f9ed88ca", size = 253961, upload-time = "2026-05-10T18:00:44.079Z" },
-    { url = "https://files.pythonhosted.org/packages/29/1e/51adf17738976e8f2b85ddef7b7aa12a0838b056c92f175941d8862767c1/coverage-7.14.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:90c1a51bcfddf645b3bb7ec333d9e94393a8e94f55642380fa8a9a5a9e636cb7", size = 255193, upload-time = "2026-05-10T18:00:45.623Z" },
-    { url = "https://files.pythonhosted.org/packages/9e/7b/5bfd7ac1df3b881c2ac7a5cbc99c7609e6296c402f5ef587cd81c6f355b3/coverage-7.14.0-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:a841fae2fadcae4f438d43b6ccc4aac2ad609f47cdb6cfdce60cbb3fe5ca7bc2", size = 257326, upload-time = "2026-05-10T18:00:47.173Z" },
-    { url = "https://files.pythonhosted.org/packages/7d/38/1d37d316b174fad3843a1d76dbdfe4398771c9ecd0515935dd9ece9cd627/coverage-7.14.0-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:c79d2319cabef1fe8e86df73371126931550804738f78ad7d31e3aad85a67367", size = 251582, upload-time = "2026-05-10T18:00:49.152Z" },
-    { url = "https://files.pythonhosted.org/packages/34/46/746704f95980ba220214e1a41e18cec5aea80a898eaa53c51bf2d645ff36/coverage-7.14.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:1b23b0c6f0b1db6ad769b7050c8b641c0bf215ded26c1816955b17b7f26edfa9", size = 253325, upload-time = "2026-05-10T18:00:51.252Z" },
-    { url = "https://files.pythonhosted.org/packages/e1/b9/bbe87206d9687b192352f893797825b5f5b15ecd3aa9c68fbff0c074d77b/coverage-7.14.0-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:55d3089079ce181a4566b1065ab28d2575eb76d8ac8f81f4fcda2bf037fee087", size = 251291, upload-time = "2026-05-10T18:00:52.816Z" },
-    { url = "https://files.pythonhosted.org/packages/46/57/b8cdb12ac0d73ef0243218bd5e22c9df8f92edab8018213a86aec67c5324/coverage-7.14.0-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:49c005cba1e2f9677fb2845dcdf9a2e72a52a17d63e8231aaaae35d9f50215ef", size = 255448, upload-time = "2026-05-10T18:00:54.548Z" },
-    { url = "https://files.pythonhosted.org/packages/1f/d4/5002019538b2036ce3c84340f54d2fd5100d55b0a6b0894eee56128d03c7/coverage-7.14.0-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:9117377b823daa28aa8635fbb08cda1cd6be3d7143257345459559aeef852d52", size = 251110, upload-time = "2026-05-10T18:00:56.122Z" },
-    { url = "https://files.pythonhosted.org/packages/37/53/20c5009477660f084e6ed60bc02a91894b8e234e617e86ecfd9aaf78e27b/coverage-7.14.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:7b79d646cf46d5cf9a9f40281d4441df5849e445726e369006d2b117710b33fe", size = 252885, upload-time = "2026-05-10T18:00:57.967Z" },
-    { url = "https://files.pythonhosted.org/packages/ae/ab/3cf6427ac9c1f1db747dbb1ce71dde47984876d4c2cfd018a3fef0a78d4d/coverage-7.14.0-cp313-cp313-win32.whl", hash = "sha256:fb609b3658479e33f9516d46f1a89dbb9b6c261366e3a11844a96ec487533dae", size = 222539, upload-time = "2026-05-10T18:00:59.581Z" },
-    { url = "https://files.pythonhosted.org/packages/8f/b8/9228523e80321c2cb4880d1f589bc0171f2f71432c35118ad04dc01decce/coverage-7.14.0-cp313-cp313-win_amd64.whl", hash = "sha256:0773d8329cf32b6fd222e4b52622c61fe8d503eb966cfc8d3c3c10c96266d50e", size = 223344, upload-time = "2026-05-10T18:01:01.531Z" },
-    { url = "https://files.pythonhosted.org/packages/a3/99/118daa192f95e3a6cb2740100fbf8797cda1734b4134ef0b5d501a7fa8f3/coverage-7.14.0-cp313-cp313-win_arm64.whl", hash = "sha256:b4e26a0f1b696faf283bffe5b8569e44e336c582439df5d53281ab89ee0cba96", size = 221966, upload-time = "2026-05-10T18:01:03.16Z" },
-    { url = "https://files.pythonhosted.org/packages/e6/f1/a46cc0c013be170216253184a32366d7cbdb9252feaec866b05c2d12a894/coverage-7.14.0-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:953f521ca9445300397e65fda3dca58b2dbd68fee983777420b57ac3c77e9f90", size = 220679, upload-time = "2026-05-10T18:01:05.058Z" },
-    { url = "https://files.pythonhosted.org/packages/64/8c/9c30a3d311a34177fa432995be7fbfc64477d8bac5630bd38055b1c9b424/coverage-7.14.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:98af83fd65ae24b1fdd03aaead967a9f523bcd2f1aab2d4f3ffda65bb568a6f1", size = 221033, upload-time = "2026-05-10T18:01:07.002Z" },
-    { url = "https://files.pythonhosted.org/packages/9a/cd/3fb5e06c3badefd0c1b47e2044fdca67f8220a4ec2e7fcfb476aa0a67c6c/coverage-7.14.0-cp313-cp313t-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:668b92e6958c4db7cf92e81caac328dfbbdbb215db2850ad28f0cbe1eea0bfbd", size = 262333, upload-time = "2026-05-10T18:01:08.903Z" },
-    { url = "https://files.pythonhosted.org/packages/a8/e6/fbc322325c7294d3e22c1ad6b79e45d0806b25228c8e5842aed6d8169aa7/coverage-7.14.0-cp313-cp313t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:9fbd898551762dea00d3fef2b1c4f99afd2c6a3ff952ea07d60a9bd5ed4f34bc", size = 264410, upload-time = "2026-05-10T18:01:10.531Z" },
-    { url = "https://files.pythonhosted.org/packages/08/92/c497b264bec1673c47cc77e26f760fcda4654cabf1f39546d1a23a3b8c35/coverage-7.14.0-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:68af363c07ecd8d4b7d4043d85cb376d7d227eceb54e5323ee45da73dbd3e426", size = 266836, upload-time = "2026-05-10T18:01:12.19Z" },
-    { url = "https://files.pythonhosted.org/packages/78/fc/045da320987f401af5d2815d351e8aa799aec859f60e29f445e3089eeedb/coverage-7.14.0-cp313-cp313t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:6e57054a583da8ac55edf24117ea4c9133032cfc4cf72aa2d48c1e5d4b52f899", size = 267974, upload-time = "2026-05-10T18:01:13.926Z" },
-    { url = "https://files.pythonhosted.org/packages/1b/ae/227b1e379497fb7a4fc3286e620f80c8a1e7cec66d45695a01639eb1af65/coverage-7.14.0-cp313-cp313t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:cc3499459bbcdd51a65b64c35ab7ed2764eaf3cba826e0df3f1d7fe2e102b70b", size = 261578, upload-time = "2026-05-10T18:01:15.564Z" },
-    { url = "https://files.pythonhosted.org/packages/a0/f5/3570342900f2acea31d33ff1590c5d8bac1a8e1a2e1c6d34a5d5e61de681/coverage-7.14.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:45899ec2138a4346ed34d601dedf5076fb74edf2d1dd9dc76a78e82397edee90", size = 264394, upload-time = "2026-05-10T18:01:17.607Z" },
-    { url = "https://files.pythonhosted.org/packages/16/29/de1bbc01c935b28f89b1dc3db85b011c055e843a8e5e3b83141c3f80af7f/coverage-7.14.0-cp313-cp313t-musllinux_1_2_i686.whl", hash = "sha256:8767486808c436f05b23ab98eb963fb29185e32a9357a166971685cb3459900f", size = 262022, upload-time = "2026-05-10T18:01:19.304Z" },
-    { url = "https://files.pythonhosted.org/packages/35/95/f53890b0bf2fc10ab168e05d38869215e73ca24c4cb521c3bb0eb62fe16b/coverage-7.14.0-cp313-cp313t-musllinux_1_2_ppc64le.whl", hash = "sha256:a3b5ddfd6aa7ddad53ee3edb231e88a2151507a43229b7d71b953916deca127d", size = 265732, upload-time = "2026-05-10T18:01:21.494Z" },
-    { url = "https://files.pythonhosted.org/packages/ed/ea/c919e259081dd2bdf0e43b87209709ba7ec2e4117c2a7f5185379c43463c/coverage-7.14.0-cp313-cp313t-musllinux_1_2_riscv64.whl", hash = "sha256:63df0fe568e698e1045792399f8ab6da3a6c2dce3182813fb92afa2641087b47", size = 260921, upload-time = "2026-05-10T18:01:23.533Z" },
-    { url = "https://files.pythonhosted.org/packages/1a/2c/c2831889705a81dc5d1c6ca12e4d8e9b95dfc146d153488a6c0ea685d28e/coverage-7.14.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:827d6397dbd95144939b18f89edf31f63e1f99633e8d5f32f22ba8bdda567477", size = 263109, upload-time = "2026-05-10T18:01:25.165Z" },
-    { url = "https://files.pythonhosted.org/packages/5a/a9/2fcae5003cac3d63fe344d2166243c2756935f48420863c5272b240d550b/coverage-7.14.0-cp313-cp313t-win32.whl", hash = "sha256:7bf43e000d24012599b879791cff41589af90674722421ef11b11a5431920bab", size = 223212, upload-time = "2026-05-10T18:01:27.157Z" },
-    { url = "https://files.pythonhosted.org/packages/3f/bb/18e94d7b14b9b398164197114a587a04ab7c9fdbe1d237eef57311c5e883/coverage-7.14.0-cp313-cp313t-win_amd64.whl", hash = "sha256:3f5549365af25d770e06b1f8f5682d9a5637d06eb494db91c6fa75d3950cc917", size = 224272, upload-time = "2026-05-10T18:01:29.107Z" },
-    { url = "https://files.pythonhosted.org/packages/db/56/4f14fad782b035c81c4ffd09159e7103d42bb1d93ac8496d04b90a11b7da/coverage-7.14.0-cp313-cp313t-win_arm64.whl", hash = "sha256:6d160217ec6fe890f16ad3a9531761589443749e448f91986c972714fad361c8", size = 222530, upload-time = "2026-05-10T18:01:31.151Z" },
-    { url = "https://files.pythonhosted.org/packages/1c/18/b9a6586d73992807c26f9a5f274131be3d76b56b18a82b9392e2a25d2e45/coverage-7.14.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:9aed9fa983514ca032790f3fe0d1c0e42ca7e16b42432af1706b50a9a46bef5d", size = 220036, upload-time = "2026-05-10T18:01:33.057Z" },
-    { url = "https://files.pythonhosted.org/packages/f3/9b/4165a1d56ddc302a0e2d518fd9d412a4fd0b57562618c78c5f21c57194f5/coverage-7.14.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:ba3b8390db29296dbbf49e91b6fe08f990743a90c8f447ba4c2ffc29670dfa63", size = 220368, upload-time = "2026-05-10T18:01:34.705Z" },
-    { url = "https://files.pythonhosted.org/packages/69/aa/c12e52a5ba148d9995229d557e3be6e554fe469addc0e9241b2f0956d8ea/coverage-7.14.0-cp314-cp314-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:3a5d8e876dfa2f102e970b183863d6dedd023d3c0eeca1fe7a9787bc5f28b212", size = 251417, upload-time = "2026-05-10T18:01:36.949Z" },
-    { url = "https://files.pythonhosted.org/packages/d7/51/ec641c26e6dca1b25a7d2035ba6ecb7c884ef1a100a9e42fbe4ce4405139/coverage-7.14.0-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:5ebb8f4614a3787d567e610bbfdf96a4798dd69a1afb1bd8ad228d4111fe6ff3", size = 253924, upload-time = "2026-05-10T18:01:38.985Z" },
-    { url = "https://files.pythonhosted.org/packages/33/c4/59c3de0bd1b538824173fd518fed51c1ce740ca5ed68e74545983f4053a9/coverage-7.14.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6b9bf47223dd8db3d4c4b2e443b02bace480d428f0822c3f991600448a176c97", size = 255269, upload-time = "2026-05-10T18:01:40.957Z" },
-    { url = "https://files.pythonhosted.org/packages/7b/a9/36dfa153a62040296f6e7febfdb20a5720622f6ef5a81a41e8237b9a5344/coverage-7.14.0-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:3485a836550b303d006d57cc06e3d5afaabc642c77050b7c985a97b13e3776b8", size = 257583, upload-time = "2026-05-10T18:01:42.607Z" },
-    { url = "https://files.pythonhosted.org/packages/26/7b/cc2c048d4114d9ab1c2409e9ee365e5ae10736df6dffcfc9444effa6c708/coverage-7.14.0-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:3e7e88110bae996d199d1693ca8ec3fd52441d426401ae963437598667b4c5eb", size = 251434, upload-time = "2026-05-10T18:01:44.537Z" },
-    { url = "https://files.pythonhosted.org/packages/ee/df/6770eaa576e604575e9a78055313250faef5faa84bd6f71a39fece519c43/coverage-7.14.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:15228a6800ce7bdf1b74800595e56db7138cecb338fdbf044806e10dcf182dfe", size = 253280, upload-time = "2026-05-10T18:01:46.175Z" },
-    { url = "https://files.pythonhosted.org/packages/ad/9e/1c0264514a3f98259a6d64765a397b2c8373e3ba59ee722a4802d3ec0c61/coverage-7.14.0-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:9d26ac7f5398bafc5b57421ad994e8a4749e8a7a0e62d05ec7d53014d5963bfa", size = 251241, upload-time = "2026-05-10T18:01:48.732Z" },
-    { url = "https://files.pythonhosted.org/packages/64/16/4efdf3e3c4079cdbf0ece56a2fea872df9e8a3e15a13a0af4400e1075944/coverage-7.14.0-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:2fb73254ff43c911c967a899e1359bc5049b4b115d6e8fbdde4937d0a2246cd5", size = 255516, upload-time = "2026-05-10T18:01:50.819Z" },
-    { url = "https://files.pythonhosted.org/packages/93/69/b1de96346603881b3d1bc8d6447c83200e1c9700ffbaff926ba01ff5724c/coverage-7.14.0-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:454a380af72c6adada298ed270d38c7a391288198dbfb8467f786f588751a90c", size = 251059, upload-time = "2026-05-10T18:01:52.773Z" },
-    { url = "https://files.pythonhosted.org/packages/a4/66/2881853e0363a5e0a724d1103e53650795367471b6afb234f8b49e713bc6/coverage-7.14.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:65c86fb646d2bd2972e96bd1a8b45817ed907cee68655d6295fe7ec031d04cca", size = 252716, upload-time = "2026-05-10T18:01:54.506Z" },
-    { url = "https://files.pythonhosted.org/packages/55/5c/0d3305d002c41dcde873dbe456491e663dc55152ca526b630b5c47efd62f/coverage-7.14.0-cp314-cp314-win32.whl", hash = "sha256:6a6516b02a6101398e19a3f44820f69bab2590697f7def4331f668b14adaf828", size = 222788, upload-time = "2026-05-10T18:01:56.487Z" },
-    { url = "https://files.pythonhosted.org/packages/f9/58/6e1b8f52fdc3184b47dc5037f5070d83a3d11042db1594b02d2a44d786c8/coverage-7.14.0-cp314-cp314-win_amd64.whl", hash = "sha256:45e0f79d8351fa76e256716df91eab12890d32678b9590df7ae1042e4bd4cf5d", size = 223600, upload-time = "2026-05-10T18:01:58.497Z" },
-    { url = "https://files.pythonhosted.org/packages/00/70/a18c408e674bc26281cadaedc7351f929bd2094e191e4b15271c30b084cc/coverage-7.14.0-cp314-cp314-win_arm64.whl", hash = "sha256:4b899594a8b2d81e5cc064a0d7f9cac2081fed91049456cae7676787e41549c9", size = 222168, upload-time = "2026-05-10T18:02:00.411Z" },
-    { url = "https://files.pythonhosted.org/packages/3d/89/2681f071d238b62aff8dfc2ab44fc24cfdb38d1c01f391a80522ff5d3a16/coverage-7.14.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:f580f8c80acd94ac72e863efe2cab791d8c38d153e0b463b92dfa000d5c84cd1", size = 220766, upload-time = "2026-05-10T18:02:02.313Z" },
-    { url = "https://files.pythonhosted.org/packages/bd/c7/c987babafd9207ffa1995e1ef1f9b26762cf4963aa768a66b6f0501e4616/coverage-7.14.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:a2bd259c442cd43c49b30fbafc51776eb19ea396faf159d26a83e6a0a5f13b0c", size = 221035, upload-time = "2026-05-10T18:02:04.017Z" },
-    { url = "https://files.pythonhosted.org/packages/5a/e9/d6a5ac3b333088143d6fc877d398a9a674dc03124a2f776e131f03864823/coverage-7.14.0-cp314-cp314t-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:a706b908dfa85538863504c624b237a3cc34232bf403c057414ebfdb3b4d9f84", size = 262405, upload-time = "2026-05-10T18:02:05.915Z" },
-    { url = "https://files.pythonhosted.org/packages/38/b1/e70838d29a7c08e22d44398a46db90815bbcbf28de06992bd9210d1a8d8e/coverage-7.14.0-cp314-cp314t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:7333cd944ee4393b9b3d3c1b598c936d4fc8d70573a4c7dacfec5590dd50e436", size = 264530, upload-time = "2026-05-10T18:02:07.582Z" },
-    { url = "https://files.pythonhosted.org/packages/6b/73/5c31ef97763288d03d9995152b96d5475b527c63d91c84b01caea894b83a/coverage-7.14.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0f162bc9a15b82d947b02651b0c7e1609d6f7a8735ca330cfadec8481dd97d5a", size = 266932, upload-time = "2026-05-10T18:02:09.401Z" },
-    { url = "https://files.pythonhosted.org/packages/e1/76/dd56d80f29c5f05b4d76f7e7c6d47cafacae017189c75c5759d24f9ff0cc/coverage-7.14.0-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:362cb78e01a5dc82009d88004cf60f2e6b6d6fcbfdec05b05af73b0abf40118f", size = 268062, upload-time = "2026-05-10T18:02:11.399Z" },
-    { url = "https://files.pythonhosted.org/packages/6e/c7/27ba85cd5b95614f159ff93ebff1901584a8d192e2e5e24c4943a7453f59/coverage-7.14.0-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:acebd068fca5512c3a6fde9c045f901613478781a73f0e82b307b214daef23fb", size = 261504, upload-time = "2026-05-10T18:02:13.257Z" },
-    { url = "https://files.pythonhosted.org/packages/13/2e/e8149f60ab5d5684c6eee881bdf34b127115cddbb958b196768dd9d63473/coverage-7.14.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:29fe3da551dface75deb2ccbf87b6b66e2e7ef38f6d89050b428be94afff3490", size = 264398, upload-time = "2026-05-10T18:02:15.063Z" },
-    { url = "https://files.pythonhosted.org/packages/d9/7f/1261b025285323225f4b4abffa5a643649dfd67e25ddca7ebcbdea3b7cb3/coverage-7.14.0-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:b4cc4fce8672fffcb09b0eafc167b396b3ba53c4a7230f54b7aaffbf6c835fa9", size = 262000, upload-time = "2026-05-10T18:02:16.756Z" },
-    { url = "https://files.pythonhosted.org/packages/d3/dc/829c54f60b9d08389439c00f813c752781c496fc5788c78d8006db4b4f2b/coverage-7.14.0-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:5d4a51aad8ba8bdcd2b8bd8f03d4aca19693fa2327a3470e4718a25b03481020", size = 265732, upload-time = "2026-05-10T18:02:18.817Z" },
-    { url = "https://files.pythonhosted.org/packages/ed/b0/70bd1419941652fa062689cba9c3eeafb8f5e6fbb890bce41c3bdda5dbd6/coverage-7.14.0-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:9f323af3e1e4f68b60b7b247e37b8515563a61375518fa59de1af48ba28a3db6", size = 260847, upload-time = "2026-05-10T18:02:20.528Z" },
-    { url = "https://files.pythonhosted.org/packages/f2/73/be40b2390656c654d35ea0015ea7ba3d945769cf80790ad5e0bb2d56d2ba/coverage-7.14.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:1a0abc7342ea9711c469dd8b821c6c311e6bc6aac1442e5fbd6b27fae0a8f3db", size = 263166, upload-time = "2026-05-10T18:02:22.337Z" },
-    { url = "https://files.pythonhosted.org/packages/29/55/4a643f712fcf7cf2881f8ec1e0ccb7b164aff3108f69b51801246c8799f2/coverage-7.14.0-cp314-cp314t-win32.whl", hash = "sha256:a9f864ef57b7172e2db87a096642dd51e179e085ab6b2c371c29e885f65c8fb2", size = 223573, upload-time = "2026-05-10T18:02:24.11Z" },
-    { url = "https://files.pythonhosted.org/packages/27/96/3acae5da0953be042c0b4dea6d6789d2f080701c77b88e44d5bd41b9219b/coverage-7.14.0-cp314-cp314t-win_amd64.whl", hash = "sha256:29943e552fdc08e082eb51400fb2f58e118a83b5542bd06531214e084399b644", size = 224680, upload-time = "2026-05-10T18:02:25.896Z" },
-    { url = "https://files.pythonhosted.org/packages/93/3d/6ab5d2dd8325d838737c6f8d83d62eb6230e0d70b87b51b57bbfd08fa767/coverage-7.14.0-cp314-cp314t-win_arm64.whl", hash = "sha256:742a73ea621953b012f2c4c2219b512180dd84489acf5b1596b0aafc55b9100b", size = 222703, upload-time = "2026-05-10T18:02:27.822Z" },
-    { url = "https://files.pythonhosted.org/packages/61/e8/cb8e80d6f9f55b99588625062822bf946cf03ed06315df4bd8397f5632a1/coverage-7.14.0-py3-none-any.whl", hash = "sha256:8de5b61163aee3d05c8a2beab6f47913df7981dad1baf82c414d99158c286ab1", size = 211764, upload-time = "2026-05-10T18:02:29.538Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/9e/5f6d56327c62b185225d145191c607e07515294a0aa6338e58805cd4a5ac/coverage-7.14.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:be9f2c802dcfce3f71298303aa5dad0dce440a76c52f2f60dacd8656dab78793", size = 220044, upload-time = "2026-05-26T20:39:29.902Z" },
+    { url = "https://files.pythonhosted.org/packages/75/92/e82aca356744cbbc0f77a0b623e38918c1872361963413a3bab5d0340393/coverage-7.14.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:6223a72fd0e4c7156353ec0f08a5f93623e1d3034d0e2683b9bb8ea674131b1d", size = 220412, upload-time = "2026-05-26T20:39:31.561Z" },
+    { url = "https://files.pythonhosted.org/packages/27/c9/385bde0bf7ed0f4bf3a7ee5367060a86b5d218718cfd6fb943c0f836b34f/coverage-7.14.1-cp313-cp313-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:7279d2110a28cebc738b6459ecda2771735a4c18465fbbd36b3288fe5ed92247", size = 251412, upload-time = "2026-05-26T20:39:33.337Z" },
+    { url = "https://files.pythonhosted.org/packages/51/8c/23faf6a2343a0d17f960a4bd56c43bc7eb4cf312f774dd6ceebd82c7d8fc/coverage-7.14.1-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:9eeb3fcbc13ba40dfbdb22d01d196a28e9cef9ed4c29b60061a1e0e823a9929d", size = 254008, upload-time = "2026-05-26T20:39:35.009Z" },
+    { url = "https://files.pythonhosted.org/packages/42/06/36f4aa9ca8a815e6036156e80706a67828bb97bd826948244f6996dda957/coverage-7.14.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5f0cfc27c539f07cf5c0a4cfe211d0b6cae039f8f40526dbaa71944e64b50a7b", size = 255241, upload-time = "2026-05-26T20:39:36.71Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/79/95266316352f90f6b1c6736bb413302edfde2453fb32422d3911642691b3/coverage-7.14.1-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:221c70f316241a78e77e607c227cefc8808d4e08f28d99c04f35694690e940be", size = 257373, upload-time = "2026-05-26T20:39:38.412Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/9c/58316d1f66c488b5fca8a0eb3e98348807813efa8a0d0833b9021be27488/coverage-7.14.1-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:da028256b04ec30e5e0114b6f76172938c313991f0a2d3d894271315cf5d5e43", size = 251635, upload-time = "2026-05-26T20:39:40.268Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/5a/ca2398a568e16fed7bb713e84ba3603a7164fb65779abe645c565ec890d5/coverage-7.14.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:76a085d7005236a767e3426148b2c407e53ad61695c562f8a81da2d373324901", size = 253373, upload-time = "2026-05-26T20:39:42.145Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/2c/0396562c32deaebe7be51d865b3a41e9a87d7561acafe1a28f53b07e019a/coverage-7.14.1-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:b553d04b5e778a8e56d57eb134aff42a92718ecba45e79c4764ecfa40efd92ff", size = 251341, upload-time = "2026-05-26T20:39:43.907Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/8f/a94f9221184c9cae1ee115820e3798e48b6b17777a9f19e46fb9a0c8dc74/coverage-7.14.1-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:46f714d2fb8ae2f4f29f23ada7f1e79b759fff5a70f94a1dac23af204c3ec9e4", size = 255497, upload-time = "2026-05-26T20:39:46.166Z" },
+    { url = "https://files.pythonhosted.org/packages/71/69/505d70e47db1eaebcd002c39759707621ef184cd6b1ae084d9f41293f323/coverage-7.14.1-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:1896f5e19ff3f0431c7ce2172adc54890fd97f86b59ced8ca1649145d9ffe35d", size = 251159, upload-time = "2026-05-26T20:39:48.03Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/aa/58681c383aa33a9d2ed40a02d7a22fbf780d1fa4d575396365777828198c/coverage-7.14.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:62fd185ef9df3c33d1c8178c5af105f762afbad96038de9a4ae100aa6297ca33", size = 252934, upload-time = "2026-05-26T20:39:49.872Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/fd/11c928cd6bdffc7074bb5965c173d9ebf517fb00205e1da524b98d29ef92/coverage-7.14.1-cp313-cp313-win32.whl", hash = "sha256:ab4af6352741a604c431c6072fce5bee33bf0f20dc7a56618d6bf6bb89e9810c", size = 222584, upload-time = "2026-05-26T20:39:51.68Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/92/fb416fc26d340dcba19518c418d6048e913186e17243982c5e435e41fa7a/coverage-7.14.1-cp313-cp313-win_amd64.whl", hash = "sha256:7af486dabe8954d03b087f0021540897afe084f04e16ff5579e08cc46f871416", size = 223394, upload-time = "2026-05-26T20:39:53.472Z" },
+    { url = "https://files.pythonhosted.org/packages/73/c6/02d56e3867972f77d5036de924643f26c056e848f00452cafb4dbc3c29b4/coverage-7.14.1-cp313-cp313-win_arm64.whl", hash = "sha256:2224f89ffd0c5605ccce1ed7a584da162bc7c55f601ab1c946bc9de31a486b42", size = 222015, upload-time = "2026-05-26T20:39:55.374Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/9e/fcc77914050df73f7662fa1f00902774c79c075a8388ab334074574bf77e/coverage-7.14.1-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:de286598cc65d2b489411174b1faec2f5a7775fb3201fd925db2a76b4030f37d", size = 220733, upload-time = "2026-05-26T20:39:57.189Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/67/2963cbdaf5cbadec44efa3a1e39eaa1f02df4079585f05387607a221e126/coverage-7.14.1-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:042c46ded7c288aeb07cf14a28b6c1e10b78fcba40171c3fa1e939377eeef0b5", size = 221086, upload-time = "2026-05-26T20:39:59.019Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/c5/8701645574e11881f2f47d8930f98bc48b5d43b25eb5b4430dfc4a2f9f48/coverage-7.14.1-cp313-cp313t-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:f4ddbe407477f04c45115d1a4e5bc480f753553b534d338d4c3358b1cdd0ea52", size = 262381, upload-time = "2026-05-26T20:40:00.822Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/28/7a64d73598263e0c5abd5084211a8474488d31b3c552ff531c719dfcff62/coverage-7.14.1-cp313-cp313t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:d13e6725992e2d2fd7d81d4f5241952d13740121dfd501da09201be39b2c003a", size = 264458, upload-time = "2026-05-26T20:40:02.506Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/d8/4969179db9f7eb4df218e69540adf829d1c835f59452513d065d15446802/coverage-7.14.1-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f747dc8edcfe740130f28f32f3995e955494285717e86ee25af51db2219df08a", size = 266884, upload-time = "2026-05-26T20:40:04.421Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/78/a45d5794dbc9bafd97afc96a4377c86c7820d78b6cf51b89bc1d4e919275/coverage-7.14.1-cp313-cp313t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:ced2f09ef276fd58611a1ef502164ad266d2b75174e5a40cabbdb4033f9f6cf2", size = 268022, upload-time = "2026-05-26T20:40:06.298Z" },
+    { url = "https://files.pythonhosted.org/packages/21/cb/4f5e354e9e3e67af96bd4e57113e6db6b22298c7168b13eec408a549903d/coverage-7.14.1-cp313-cp313t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:b84800013769a78ccb9ef4659402e26d06867e337b61ec365f77ad008adea80e", size = 261631, upload-time = "2026-05-26T20:40:08.226Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/49/eced49af4cb996d5d8b7e94e736175c513e4facd3398507b89892b4326d8/coverage-7.14.1-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:ea8cd6ca0ee9f616aaef3afc6882e32c2cbf18b00d96313ffd76af650574034d", size = 264443, upload-time = "2026-05-26T20:40:10.137Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/d8/5603a88a7c5913a6b54f6cb1a8c46f7b39cbb30f27cd3f492908da09b2d7/coverage-7.14.1-cp313-cp313t-musllinux_1_2_i686.whl", hash = "sha256:aa5e304a873fabddc11e484e9b6b738bd38bd7bed17b09aa84eecf5332e8b8bb", size = 262069, upload-time = "2026-05-26T20:40:11.999Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/59/2ae3cb79da554a06c8619d6c88ea19dd1e4aed4b834b6a83bb1fa243bdc5/coverage-7.14.1-cp313-cp313t-musllinux_1_2_ppc64le.whl", hash = "sha256:5a1c5215be81035e629d5bc756650634d0bf31991038db7a0eccb90f025ce16d", size = 265780, upload-time = "2026-05-26T20:40:13.858Z" },
+    { url = "https://files.pythonhosted.org/packages/af/5f/b130c1dc999031f2648bd25317fbce505ad8d5562079b4ed81e736a84967/coverage-7.14.1-cp313-cp313t-musllinux_1_2_riscv64.whl", hash = "sha256:79058c47dae6788504b5effb319961bcd72d7240551464b91d474bc0ed186d69", size = 260970, upload-time = "2026-05-26T20:40:16.142Z" },
+    { url = "https://files.pythonhosted.org/packages/87/d1/ec13ccddeb48ec963bdfa72a11224bac2584bd045ba13beca82f8113e9c7/coverage-7.14.1-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:370c5afae3fa0658e11694a32b24c2778f6bc2d17718121f94ee185e69f26b54", size = 263157, upload-time = "2026-05-26T20:40:18.382Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/c2/cd91ead503045161092d3845f7bb95ea2f25131ce96d3e314dd835d91b9c/coverage-7.14.1-cp313-cp313t-win32.whl", hash = "sha256:3758dd0a7f1fa57365ef2e781df0f0731d38b6e3772259d13dae4bd8a958d4b1", size = 223259, upload-time = "2026-05-26T20:40:20.381Z" },
+    { url = "https://files.pythonhosted.org/packages/71/9f/1e28d97e6bd2c76b07f38b7c02870f1371255ff6717f54eca578fcbbdd0e/coverage-7.14.1-cp313-cp313t-win_amd64.whl", hash = "sha256:6ff665fb023a77386fe11685190cee1f60a7d635994a30d9b0a061533d470fce", size = 224320, upload-time = "2026-05-26T20:40:22.316Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/e0/d936e908f0e1efa55e52b91e01b52f1055cef5e1ab2718493390ed8e2fb8/coverage-7.14.1-cp313-cp313t-win_arm64.whl", hash = "sha256:17a5a241e5997621a956a7f402a7433ef4221e5152809b785bec79e2323799f1", size = 222577, upload-time = "2026-05-26T20:40:24.894Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/34/fc2f101b151af3799a101f0550b0454aa008afdc0add677394ec4aa8ea10/coverage-7.14.1-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:d5ed429d0b8edaac649e889b4ffcedb6c80b06629a3f93050e3dddfb99235bee", size = 220091, upload-time = "2026-05-26T20:40:27.249Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/a7/1ebae2ab5b961b5c79bb09fe7b3ac99edb190d8be4a8c510b2cf66f46468/coverage-7.14.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:8011224a62280e50dab346960c03cf47aca1a1e09e608c0fb33fd6e0cc8e9500", size = 220421, upload-time = "2026-05-26T20:40:30.084Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/90/92aca9cf0acc95123c96cd1eb1f08917897a7f5dee01e15738922971ec31/coverage-7.14.1-cp314-cp314-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:12c42ec1e14f553c4f817e989365982e646e27211f10a0f717855b94a79c8906", size = 251466, upload-time = "2026-05-26T20:40:32.542Z" },
+    { url = "https://files.pythonhosted.org/packages/26/2b/78048cbe3b999f6cbf9cc0d90abba6a88a3e0863a8c1c6cbc762f3f8802f/coverage-7.14.1-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:06144cd511cf2624873a035c5069cf297144f6e77a73ee3d7a55b605ec5efb42", size = 253973, upload-time = "2026-05-26T20:40:34.473Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/21/c2e33b29d1cfde484a19d437afc343c6cd30b08d78cbbf9f5aff14e57b2b/coverage-7.14.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a311d8e1da24be5c1ccf85cbfb06315dbaa1703d5a1eab3f6432c72b837917c8", size = 255318, upload-time = "2026-05-26T20:40:38.154Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/ee/aad2f108d63b769121005302f16bf66db8625c88ceaba466942e09a2607e/coverage-7.14.1-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:c79cead5b5bc584d9c71451cb984d0e3a84e0c0937379c8efcbf27c8d661b851", size = 257633, upload-time = "2026-05-26T20:40:40.164Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/f8/11a2c29b4fd76d9849f81d0bb812ec0017a9396df3217214e38934a8c837/coverage-7.14.1-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:dcbf65f1f66a26cdd88c35cf68fb4729c5d1cd2e88added72420541dfb212034", size = 251488, upload-time = "2026-05-26T20:40:42.631Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/b8/9a5820de4b8ac2b71d85e3b5fb49108d7469c665f0e2ad0dd7569023e305/coverage-7.14.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:fd86572566fb40189a8260446158235159bc7a82dfbc87a3b39cf4fb57fcec1c", size = 253329, upload-time = "2026-05-26T20:40:45.208Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/ff/f33e4823667e27548e8fd8df44217515303f9808d0ff29817db56f87d990/coverage-7.14.1-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:7771b601718fdde84832c3a434ca9bbf4ae9adbc49d84198b4110700c3c77c36", size = 251291, upload-time = "2026-05-26T20:40:47.502Z" },
+    { url = "https://files.pythonhosted.org/packages/68/9b/489db0ebb209054766b90a9014a45f6d26eb724c02ec21311c3733b5a644/coverage-7.14.1-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:39b21e212c55af06fa375e3dbf90a8a8e38792f3a910c580066d23563830ddd5", size = 255564, upload-time = "2026-05-26T20:40:49.372Z" },
+    { url = "https://files.pythonhosted.org/packages/27/b5/16bc2d4c2409b23c7737edb68c83bc89e345f378050549fe1d75ac7d34d5/coverage-7.14.1-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:f2302660e32562a532b442480121aef8aa61a5bdb20b30bf0adab29f10a5a4b4", size = 251107, upload-time = "2026-05-26T20:40:51.677Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/0c/2629997469a00cd069d588a41c9dc887610f2775ae89d250c4791e65272a/coverage-7.14.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:03a6f93c1ec3b7f2e77b5dbcc5573a2c21f12529a5c6bbe0f16f72303cc2fa4d", size = 252764, upload-time = "2026-05-26T20:40:54.267Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/ee/f78d63c8f079e0d7211c7e2401fa17e311514534ba61bae03e4b287ce4ab/coverage-7.14.1-cp314-cp314-win32.whl", hash = "sha256:8a3ce026d73290f42f08dafecbd82c193a74df280461fbf97300fec51fd133ee", size = 222837, upload-time = "2026-05-26T20:40:56.496Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/b9/be539854f93a70dfbeec69117f33ec70dc42ff0b65b5b07ab8d40d04228e/coverage-7.14.1-cp314-cp314-win_amd64.whl", hash = "sha256:114c95ef29302423b87d159075805f4ab973254a2638a5d7d046c94887cc87d7", size = 223650, upload-time = "2026-05-26T20:40:58.351Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/9e/24e2842fef40f35ac82ba3a7719c8023d011bf3bf652d0675316a9d088a1/coverage-7.14.1-cp314-cp314-win_arm64.whl", hash = "sha256:a07891c3f4805442b31b71e84ba3cf29ed1aa9a428284e06deeb4b23e5b46343", size = 222218, upload-time = "2026-05-26T20:41:00.321Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/1d/ac0a9df5fe31c1e8bdd658074905fc12844a05c1a7e3fdb8417e97c31e23/coverage-7.14.1-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:1101a5ebb083aecb625ebb6209d4105b58f647b093cb2dc8122d7b33f743cfe1", size = 220822, upload-time = "2026-05-26T20:41:02.281Z" },
+    { url = "https://files.pythonhosted.org/packages/32/cf/f964fd9aff20323f9f1a726c97135f8a76bcd87b92dad141a456a43f3c64/coverage-7.14.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:851b9e1e4e8a4608e77c79714b2e77c0970d2ed7202a05e92ae407817481887b", size = 221084, upload-time = "2026-05-26T20:41:04.593Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/5e/7e5ef2aba844de2b80d678619fcf0841b42e3f37f16411226f3fe4c1016f/coverage-7.14.1-cp314-cp314t-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:d5b89cdfb2ee051b71e8c3c70bd81a9eff81100f736a269136fe1a68efe00474", size = 262454, upload-time = "2026-05-26T20:41:06.641Z" },
+    { url = "https://files.pythonhosted.org/packages/64/62/75809bded87015cc4935524218a2a8ed8dd1a8498bfed30a2f4f7a4b4d34/coverage-7.14.1-cp314-cp314t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:0177614a0370f227888b4e436a7c55686d6a9f90eb1ade2b624ba685a1686e86", size = 264578, upload-time = "2026-05-26T20:41:08.556Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/42/d33392dc14633525012d2d504fa1a33b05538bf535f5c1d64675e5754b78/coverage-7.14.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2d69af5dea2de76fc485a83032a630523f985198b7e25be901ec60181587b01e", size = 266981, upload-time = "2026-05-26T20:41:10.824Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/49/0157c4428c2aca7f1e09d5565930586fd5ae36f1655f08b0daa7cf1fcae1/coverage-7.14.1-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:35ab22d91de736e8966b980dc355cbcdd2c6dbbcfe275f9a2991bc8a91b3df65", size = 268112, upload-time = "2026-05-26T20:41:12.966Z" },
+    { url = "https://files.pythonhosted.org/packages/96/26/86b9ce71f4092b1ed325ce1421698081df1286b833400b6836912834d6e0/coverage-7.14.1-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:357d4e32935c36588aaba057d734fa32428c360c9fc2e4442afbf1b646beee6e", size = 261558, upload-time = "2026-05-26T20:41:15Z" },
+    { url = "https://files.pythonhosted.org/packages/20/4c/c311210c5472cf5401d8422b0d7812cdd520f24417673afabda6c323faca/coverage-7.14.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:51bd64741cc6fa065abd300ede1afe5a5291ece9c31da8b24884deda48bcc3f8", size = 264447, upload-time = "2026-05-26T20:41:17.369Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/71/59513f8710ed3e6b0ac0a050a5b7e977bb9c9e880354863b5d00d8809256/coverage-7.14.1-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:9132cd363a68a4c3daa7c8704a654b1e39d3360f6f5b8ddd470608a945236c07", size = 262048, upload-time = "2026-05-26T20:41:19.309Z" },
+    { url = "https://files.pythonhosted.org/packages/84/8d/bceed32dc494f5bbf50f775cd2e78ca814953942b5ea28d3c1c3ac316f14/coverage-7.14.1-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:07c6290b1697b862c0478eab545eec949a0d0e4d6d03497f446d706da3b4f2de", size = 265781, upload-time = "2026-05-26T20:41:21.559Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/c5/9348fe40dbfd4991aaf78df2c6c3098bfb2cc834d1fd362a64b4efef855a/coverage-7.14.1-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:5ea0c297e27133853b4d8a3eb799bff5a2dbd9f2f41537a240d337ac9b4df890", size = 260896, upload-time = "2026-05-26T20:41:23.428Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/92/1ea0f03929da7cf87206b1fa24f4c8e9c158be0455481af29ec0a1f3503f/coverage-7.14.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:01b7733daad0237daa01ef80fe2dfceffc911e6a17fa7b55d14aa8214eaaaecd", size = 263214, upload-time = "2026-05-26T20:41:25.419Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/a9/b2493c054c0e01a643266742ab45e15744e60743f9260cd930c7142b1124/coverage-7.14.1-cp314-cp314t-win32.whl", hash = "sha256:6adc5a36984624a70bf11d7184e20fa0a49aa7c47ffab43804106a1a695ea22e", size = 223624, upload-time = "2026-05-26T20:41:27.795Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/bd/3e1e6a57fccd2d7c83fcdf338e93ba98eb85c6e877dd34731ac585375490/coverage-7.14.1-cp314-cp314t-win_amd64.whl", hash = "sha256:ddf799247318f34dbcd2efa8c95a8d0642674e926bb1774cf9b63dfd2a389d1c", size = 224728, upload-time = "2026-05-26T20:41:30.098Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/d7/31066cf1d2f0c6c797fce911bcfa01dd35642dc6da992a950256097c5860/coverage-7.14.1-cp314-cp314t-win_arm64.whl", hash = "sha256:145986fe66647eb489f18d9a997567a3fd358584c4b5a808769113abc07466af", size = 222752, upload-time = "2026-05-26T20:41:32.123Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/3c/1a983b9a745d7f83d53f057bcc5bf79ba6a2bbc08266b3f0c7d6fe630c9b/coverage-7.14.1-py3-none-any.whl", hash = "sha256:a252f21c27e38347e60111a3266b03827422a7d5525951aceee313aa68bab1d2", size = 211815, upload-time = "2026-05-26T20:41:34.078Z" },
 ]
 
 [[package]]
@@ -653,79 +666,79 @@ wheels = [
 
 [[package]]
 name = "cryptography"
-version = "46.0.7"
+version = "48.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "cffi", marker = "platform_python_implementation != 'PyPy'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/47/93/ac8f3d5ff04d54bc814e961a43ae5b0b146154c89c61b47bb07557679b18/cryptography-46.0.7.tar.gz", hash = "sha256:e4cfd68c5f3e0bfdad0d38e023239b96a2fe84146481852dffbcca442c245aa5", size = 750652, upload-time = "2026-04-08T01:57:54.692Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/9f/a9/db8f313fdcd85d767d4973515e1db101f9c71f95fced83233de224673757/cryptography-48.0.0.tar.gz", hash = "sha256:5c3932f4436d1cccb036cb0eaef46e6e2db91035166f1ad6505c3c9d5a635920", size = 832984, upload-time = "2026-05-04T22:59:38.133Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0b/5d/4a8f770695d73be252331e60e526291e3df0c9b27556a90a6b47bccca4c2/cryptography-46.0.7-cp311-abi3-macosx_10_9_universal2.whl", hash = "sha256:ea42cbe97209df307fdc3b155f1b6fa2577c0defa8f1f7d3be7d31d189108ad4", size = 7179869, upload-time = "2026-04-08T01:56:17.157Z" },
-    { url = "https://files.pythonhosted.org/packages/5f/45/6d80dc379b0bbc1f9d1e429f42e4cb9e1d319c7a8201beffd967c516ea01/cryptography-46.0.7-cp311-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:b36a4695e29fe69215d75960b22577197aca3f7a25b9cf9d165dcfe9d80bc325", size = 4275492, upload-time = "2026-04-08T01:56:19.36Z" },
-    { url = "https://files.pythonhosted.org/packages/4a/9a/1765afe9f572e239c3469f2cb429f3ba7b31878c893b246b4b2994ffe2fe/cryptography-46.0.7-cp311-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:5ad9ef796328c5e3c4ceed237a183f5d41d21150f972455a9d926593a1dcb308", size = 4426670, upload-time = "2026-04-08T01:56:21.415Z" },
-    { url = "https://files.pythonhosted.org/packages/8f/3e/af9246aaf23cd4ee060699adab1e47ced3f5f7e7a8ffdd339f817b446462/cryptography-46.0.7-cp311-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:73510b83623e080a2c35c62c15298096e2a5dc8d51c3b4e1740211839d0dea77", size = 4280275, upload-time = "2026-04-08T01:56:23.539Z" },
-    { url = "https://files.pythonhosted.org/packages/0f/54/6bbbfc5efe86f9d71041827b793c24811a017c6ac0fd12883e4caa86b8ed/cryptography-46.0.7-cp311-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:cbd5fb06b62bd0721e1170273d3f4d5a277044c47ca27ee257025146c34cbdd1", size = 4928402, upload-time = "2026-04-08T01:56:25.624Z" },
-    { url = "https://files.pythonhosted.org/packages/2d/cf/054b9d8220f81509939599c8bdbc0c408dbd2bdd41688616a20731371fe0/cryptography-46.0.7-cp311-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:420b1e4109cc95f0e5700eed79908cef9268265c773d3a66f7af1eef53d409ef", size = 4459985, upload-time = "2026-04-08T01:56:27.309Z" },
-    { url = "https://files.pythonhosted.org/packages/f9/46/4e4e9c6040fb01c7467d47217d2f882daddeb8828f7df800cb806d8a2288/cryptography-46.0.7-cp311-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:24402210aa54baae71d99441d15bb5a1919c195398a87b563df84468160a65de", size = 3990652, upload-time = "2026-04-08T01:56:29.095Z" },
-    { url = "https://files.pythonhosted.org/packages/36/5f/313586c3be5a2fbe87e4c9a254207b860155a8e1f3cca99f9910008e7d08/cryptography-46.0.7-cp311-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:8a469028a86f12eb7d2fe97162d0634026d92a21f3ae0ac87ed1c4a447886c83", size = 4279805, upload-time = "2026-04-08T01:56:30.928Z" },
-    { url = "https://files.pythonhosted.org/packages/69/33/60dfc4595f334a2082749673386a4d05e4f0cf4df8248e63b2c3437585f2/cryptography-46.0.7-cp311-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:9694078c5d44c157ef3162e3bf3946510b857df5a3955458381d1c7cfc143ddb", size = 4892883, upload-time = "2026-04-08T01:56:32.614Z" },
-    { url = "https://files.pythonhosted.org/packages/c7/0b/333ddab4270c4f5b972f980adef4faa66951a4aaf646ca067af597f15563/cryptography-46.0.7-cp311-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:42a1e5f98abb6391717978baf9f90dc28a743b7d9be7f0751a6f56a75d14065b", size = 4459756, upload-time = "2026-04-08T01:56:34.306Z" },
-    { url = "https://files.pythonhosted.org/packages/d2/14/633913398b43b75f1234834170947957c6b623d1701ffc7a9600da907e89/cryptography-46.0.7-cp311-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:91bbcb08347344f810cbe49065914fe048949648f6bd5c2519f34619142bbe85", size = 4410244, upload-time = "2026-04-08T01:56:35.977Z" },
-    { url = "https://files.pythonhosted.org/packages/10/f2/19ceb3b3dc14009373432af0c13f46aa08e3ce334ec6eff13492e1812ccd/cryptography-46.0.7-cp311-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:5d1c02a14ceb9148cc7816249f64f623fbfee39e8c03b3650d842ad3f34d637e", size = 4674868, upload-time = "2026-04-08T01:56:38.034Z" },
-    { url = "https://files.pythonhosted.org/packages/1a/bb/a5c213c19ee94b15dfccc48f363738633a493812687f5567addbcbba9f6f/cryptography-46.0.7-cp311-abi3-win32.whl", hash = "sha256:d23c8ca48e44ee015cd0a54aeccdf9f09004eba9fc96f38c911011d9ff1bd457", size = 3026504, upload-time = "2026-04-08T01:56:39.666Z" },
-    { url = "https://files.pythonhosted.org/packages/2b/02/7788f9fefa1d060ca68717c3901ae7fffa21ee087a90b7f23c7a603c32ae/cryptography-46.0.7-cp311-abi3-win_amd64.whl", hash = "sha256:397655da831414d165029da9bc483bed2fe0e75dde6a1523ec2fe63f3c46046b", size = 3488363, upload-time = "2026-04-08T01:56:41.893Z" },
-    { url = "https://files.pythonhosted.org/packages/7b/56/15619b210e689c5403bb0540e4cb7dbf11a6bf42e483b7644e471a2812b3/cryptography-46.0.7-cp314-cp314t-macosx_10_9_universal2.whl", hash = "sha256:d151173275e1728cf7839aaa80c34fe550c04ddb27b34f48c232193df8db5842", size = 7119671, upload-time = "2026-04-08T01:56:44Z" },
-    { url = "https://files.pythonhosted.org/packages/74/66/e3ce040721b0b5599e175ba91ab08884c75928fbeb74597dd10ef13505d2/cryptography-46.0.7-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:db0f493b9181c7820c8134437eb8b0b4792085d37dbb24da050476ccb664e59c", size = 4268551, upload-time = "2026-04-08T01:56:46.071Z" },
-    { url = "https://files.pythonhosted.org/packages/03/11/5e395f961d6868269835dee1bafec6a1ac176505a167f68b7d8818431068/cryptography-46.0.7-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:ebd6daf519b9f189f85c479427bbd6e9c9037862cf8fe89ee35503bd209ed902", size = 4408887, upload-time = "2026-04-08T01:56:47.718Z" },
-    { url = "https://files.pythonhosted.org/packages/40/53/8ed1cf4c3b9c8e611e7122fb56f1c32d09e1fff0f1d77e78d9ff7c82653e/cryptography-46.0.7-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:b7b412817be92117ec5ed95f880defe9cf18a832e8cafacf0a22337dc1981b4d", size = 4271354, upload-time = "2026-04-08T01:56:49.312Z" },
-    { url = "https://files.pythonhosted.org/packages/50/46/cf71e26025c2e767c5609162c866a78e8a2915bbcfa408b7ca495c6140c4/cryptography-46.0.7-cp314-cp314t-manylinux_2_28_ppc64le.whl", hash = "sha256:fbfd0e5f273877695cb93baf14b185f4878128b250cc9f8e617ea0c025dfb022", size = 4905845, upload-time = "2026-04-08T01:56:50.916Z" },
-    { url = "https://files.pythonhosted.org/packages/c0/ea/01276740375bac6249d0a971ebdf6b4dc9ead0ee0a34ef3b5a88c1a9b0d4/cryptography-46.0.7-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:ffca7aa1d00cf7d6469b988c581598f2259e46215e0140af408966a24cf086ce", size = 4444641, upload-time = "2026-04-08T01:56:52.882Z" },
-    { url = "https://files.pythonhosted.org/packages/3d/4c/7d258f169ae71230f25d9f3d06caabcff8c3baf0978e2b7d65e0acac3827/cryptography-46.0.7-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:60627cf07e0d9274338521205899337c5d18249db56865f943cbe753aa96f40f", size = 3967749, upload-time = "2026-04-08T01:56:54.597Z" },
-    { url = "https://files.pythonhosted.org/packages/b5/2a/2ea0767cad19e71b3530e4cad9605d0b5e338b6a1e72c37c9c1ceb86c333/cryptography-46.0.7-cp314-cp314t-manylinux_2_34_aarch64.whl", hash = "sha256:80406c3065e2c55d7f49a9550fe0c49b3f12e5bfff5dedb727e319e1afb9bf99", size = 4270942, upload-time = "2026-04-08T01:56:56.416Z" },
-    { url = "https://files.pythonhosted.org/packages/41/3d/fe14df95a83319af25717677e956567a105bb6ab25641acaa093db79975d/cryptography-46.0.7-cp314-cp314t-manylinux_2_34_ppc64le.whl", hash = "sha256:c5b1ccd1239f48b7151a65bc6dd54bcfcc15e028c8ac126d3fada09db0e07ef1", size = 4871079, upload-time = "2026-04-08T01:56:58.31Z" },
-    { url = "https://files.pythonhosted.org/packages/9c/59/4a479e0f36f8f378d397f4eab4c850b4ffb79a2f0d58704b8fa0703ddc11/cryptography-46.0.7-cp314-cp314t-manylinux_2_34_x86_64.whl", hash = "sha256:d5f7520159cd9c2154eb61eb67548ca05c5774d39e9c2c4339fd793fe7d097b2", size = 4443999, upload-time = "2026-04-08T01:57:00.508Z" },
-    { url = "https://files.pythonhosted.org/packages/28/17/b59a741645822ec6d04732b43c5d35e4ef58be7bfa84a81e5ae6f05a1d33/cryptography-46.0.7-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:fcd8eac50d9138c1d7fc53a653ba60a2bee81a505f9f8850b6b2888555a45d0e", size = 4399191, upload-time = "2026-04-08T01:57:02.654Z" },
-    { url = "https://files.pythonhosted.org/packages/59/6a/bb2e166d6d0e0955f1e9ff70f10ec4b2824c9cfcdb4da772c7dd69cc7d80/cryptography-46.0.7-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:65814c60f8cc400c63131584e3e1fad01235edba2614b61fbfbfa954082db0ee", size = 4655782, upload-time = "2026-04-08T01:57:04.592Z" },
-    { url = "https://files.pythonhosted.org/packages/95/b6/3da51d48415bcb63b00dc17c2eff3a651b7c4fed484308d0f19b30e8cb2c/cryptography-46.0.7-cp314-cp314t-win32.whl", hash = "sha256:fdd1736fed309b4300346f88f74cd120c27c56852c3838cab416e7a166f67298", size = 3002227, upload-time = "2026-04-08T01:57:06.91Z" },
-    { url = "https://files.pythonhosted.org/packages/32/a8/9f0e4ed57ec9cebe506e58db11ae472972ecb0c659e4d52bbaee80ca340a/cryptography-46.0.7-cp314-cp314t-win_amd64.whl", hash = "sha256:e06acf3c99be55aa3b516397fe42f5855597f430add9c17fa46bf2e0fb34c9bb", size = 3475332, upload-time = "2026-04-08T01:57:08.807Z" },
-    { url = "https://files.pythonhosted.org/packages/a7/7f/cd42fc3614386bc0c12f0cb3c4ae1fc2bbca5c9662dfed031514911d513d/cryptography-46.0.7-cp38-abi3-macosx_10_9_universal2.whl", hash = "sha256:462ad5cb1c148a22b2e3bcc5ad52504dff325d17daf5df8d88c17dda1f75f2a4", size = 7165618, upload-time = "2026-04-08T01:57:10.645Z" },
-    { url = "https://files.pythonhosted.org/packages/a5/d0/36a49f0262d2319139d2829f773f1b97ef8aef7f97e6e5bd21455e5a8fb5/cryptography-46.0.7-cp38-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:84d4cced91f0f159a7ddacad249cc077e63195c36aac40b4150e7a57e84fffe7", size = 4270628, upload-time = "2026-04-08T01:57:12.885Z" },
-    { url = "https://files.pythonhosted.org/packages/8a/6c/1a42450f464dda6ffbe578a911f773e54dd48c10f9895a23a7e88b3e7db5/cryptography-46.0.7-cp38-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:128c5edfe5e5938b86b03941e94fac9ee793a94452ad1365c9fc3f4f62216832", size = 4415405, upload-time = "2026-04-08T01:57:14.923Z" },
-    { url = "https://files.pythonhosted.org/packages/9a/92/4ed714dbe93a066dc1f4b4581a464d2d7dbec9046f7c8b7016f5286329e2/cryptography-46.0.7-cp38-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:5e51be372b26ef4ba3de3c167cd3d1022934bc838ae9eaad7e644986d2a3d163", size = 4272715, upload-time = "2026-04-08T01:57:16.638Z" },
-    { url = "https://files.pythonhosted.org/packages/b7/e6/a26b84096eddd51494bba19111f8fffe976f6a09f132706f8f1bf03f51f7/cryptography-46.0.7-cp38-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:cdf1a610ef82abb396451862739e3fc93b071c844399e15b90726ef7470eeaf2", size = 4918400, upload-time = "2026-04-08T01:57:19.021Z" },
-    { url = "https://files.pythonhosted.org/packages/c7/08/ffd537b605568a148543ac3c2b239708ae0bd635064bab41359252ef88ed/cryptography-46.0.7-cp38-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:1d25aee46d0c6f1a501adcddb2d2fee4b979381346a78558ed13e50aa8a59067", size = 4450634, upload-time = "2026-04-08T01:57:21.185Z" },
-    { url = "https://files.pythonhosted.org/packages/16/01/0cd51dd86ab5b9befe0d031e276510491976c3a80e9f6e31810cce46c4ad/cryptography-46.0.7-cp38-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:cdfbe22376065ffcf8be74dc9a909f032df19bc58a699456a21712d6e5eabfd0", size = 3985233, upload-time = "2026-04-08T01:57:22.862Z" },
-    { url = "https://files.pythonhosted.org/packages/92/49/819d6ed3a7d9349c2939f81b500a738cb733ab62fbecdbc1e38e83d45e12/cryptography-46.0.7-cp38-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:abad9dac36cbf55de6eb49badd4016806b3165d396f64925bf2999bcb67837ba", size = 4271955, upload-time = "2026-04-08T01:57:24.814Z" },
-    { url = "https://files.pythonhosted.org/packages/80/07/ad9b3c56ebb95ed2473d46df0847357e01583f4c52a85754d1a55e29e4d0/cryptography-46.0.7-cp38-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:935ce7e3cfdb53e3536119a542b839bb94ec1ad081013e9ab9b7cfd478b05006", size = 4879888, upload-time = "2026-04-08T01:57:26.88Z" },
-    { url = "https://files.pythonhosted.org/packages/b8/c7/201d3d58f30c4c2bdbe9b03844c291feb77c20511cc3586daf7edc12a47b/cryptography-46.0.7-cp38-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:35719dc79d4730d30f1c2b6474bd6acda36ae2dfae1e3c16f2051f215df33ce0", size = 4449961, upload-time = "2026-04-08T01:57:29.068Z" },
-    { url = "https://files.pythonhosted.org/packages/a5/ef/649750cbf96f3033c3c976e112265c33906f8e462291a33d77f90356548c/cryptography-46.0.7-cp38-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:7bbc6ccf49d05ac8f7d7b5e2e2c33830d4fe2061def88210a126d130d7f71a85", size = 4401696, upload-time = "2026-04-08T01:57:31.029Z" },
-    { url = "https://files.pythonhosted.org/packages/41/52/a8908dcb1a389a459a29008c29966c1d552588d4ae6d43f3a1a4512e0ebe/cryptography-46.0.7-cp38-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:a1529d614f44b863a7b480c6d000fe93b59acee9c82ffa027cfadc77521a9f5e", size = 4664256, upload-time = "2026-04-08T01:57:33.144Z" },
-    { url = "https://files.pythonhosted.org/packages/4b/fa/f0ab06238e899cc3fb332623f337a7364f36f4bb3f2534c2bb95a35b132c/cryptography-46.0.7-cp38-abi3-win32.whl", hash = "sha256:f247c8c1a1fb45e12586afbb436ef21ff1e80670b2861a90353d9b025583d246", size = 3013001, upload-time = "2026-04-08T01:57:34.933Z" },
-    { url = "https://files.pythonhosted.org/packages/d2/f1/00ce3bde3ca542d1acd8f8cfa38e446840945aa6363f9b74746394b14127/cryptography-46.0.7-cp38-abi3-win_amd64.whl", hash = "sha256:506c4ff91eff4f82bdac7633318a526b1d1309fc07ca76a3ad182cb5b686d6d3", size = 3472985, upload-time = "2026-04-08T01:57:36.714Z" },
+    { url = "https://files.pythonhosted.org/packages/df/3d/01f6dd9190170a5a241e0e98c2d04be3664a9e6f5b9b872cde63aff1c3dd/cryptography-48.0.0-cp311-abi3-macosx_10_9_universal2.whl", hash = "sha256:0c558d2cdffd8f4bbb30fc7134c74d2ca9a476f830bb053074498fbc86f41ed6", size = 8001587, upload-time = "2026-05-04T22:57:36.803Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/6e/e90527eef33f309beb811cf7c982c3aeffcce8e3edb178baa4ca3ae4a6fa/cryptography-48.0.0-cp311-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:f5333311663ea94f75dd408665686aaf426563556bb5283554a3539177e03b8c", size = 4690433, upload-time = "2026-05-04T22:57:40.373Z" },
+    { url = "https://files.pythonhosted.org/packages/90/04/673510ed51ddff56575f306cf1617d80411ee76831ccd3097599140efdfe/cryptography-48.0.0-cp311-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:7995ef305d7165c3f11ae07f2517e5a4f1d5c18da1376a0a9ed496336b69e5f3", size = 4710620, upload-time = "2026-05-04T22:57:42.935Z" },
+    { url = "https://files.pythonhosted.org/packages/14/d5/e9c4ef932c8d800490c34d8bd589d64a31d5890e27ec9e9ad532be893294/cryptography-48.0.0-cp311-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:40ba1f85eaa6959837b1d51c9767e230e14612eea4ef110ee8854ada22da1bf5", size = 4696283, upload-time = "2026-05-04T22:57:45.294Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/29/174b9dfb60b12d59ecfc6cfa04bc88c21b42a54f01b8aae09bb6e51e4c7f/cryptography-48.0.0-cp311-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:369a6348999f94bbd53435c894377b20ab95f25a9065c283570e70150d8abc3c", size = 5296573, upload-time = "2026-05-04T22:57:47.933Z" },
+    { url = "https://files.pythonhosted.org/packages/95/38/0d29a6fd7d0d1373f0c0c88a04ba20e359b257753ac497564cd660fc1d55/cryptography-48.0.0-cp311-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:a0e692c683f4df67815a2d258b324e66f4738bd7a96a218c826dce4f4bd05d8f", size = 4743677, upload-time = "2026-05-04T22:57:50.067Z" },
+    { url = "https://files.pythonhosted.org/packages/30/be/eef653013d5c63b6a490529e0316f9ac14a37602965d4903efed1399f32b/cryptography-48.0.0-cp311-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:18349bbc56f4743c8b12dc32e2bccb2cf83ee8b69a3bba74ef8ae857e26b3d25", size = 4330808, upload-time = "2026-05-04T22:57:52.301Z" },
+    { url = "https://files.pythonhosted.org/packages/84/9e/500463e87abb7a0a0f9f256ec21123ecde0a7b5541a15e840ea54551fd81/cryptography-48.0.0-cp311-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:7e8eac43dfca5c4cccc6dad9a80504436fca53bb9bc3100a2386d730fbe6b602", size = 4695941, upload-time = "2026-05-04T22:57:54.603Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/dc/7303087450c2ec9e7fbb750e17c2abfbc658f23cbd0e54009509b7cc4091/cryptography-48.0.0-cp311-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:9ccdac7d40688ecb5a3b4a604b8a88c8002e3442d6c60aead1db2a89a041560c", size = 5252579, upload-time = "2026-05-04T22:57:57.207Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/c0/7101d3b7215edcdc90c45da544961fd8ed2d6448f77577460fa75a8443f7/cryptography-48.0.0-cp311-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:bd72e68b06bb1e96913f97dd4901119bc17f39d4586a5adf2d3e47bc2b9d58b5", size = 4743326, upload-time = "2026-05-04T22:57:59.535Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/d8/5b833bad13016f562ab9d063d68199a4bd121d18458e439515601d3357ec/cryptography-48.0.0-cp311-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:59baa2cb386c4f0b9905bd6eb4c2a79a69a128408fd31d32ca4d7102d4156321", size = 4826672, upload-time = "2026-05-04T22:58:01.996Z" },
+    { url = "https://files.pythonhosted.org/packages/98/e1/7074eb8bf3c135558c73fc2bcf0f5633f912e6fb87e868a55c454080ef09/cryptography-48.0.0-cp311-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:9249e3cd978541d665967ac2cb2787fd6a62bddf1e75b3e347a594d7dacf4f74", size = 4972574, upload-time = "2026-05-04T22:58:03.968Z" },
+    { url = "https://files.pythonhosted.org/packages/04/70/e5a1b41d325f797f39427aa44ef8baf0be500065ab6d8e10369d850d4a4f/cryptography-48.0.0-cp311-abi3-win32.whl", hash = "sha256:9c459db21422be75e2809370b829a87eb37f74cd785fc4aa9ea1e5f43b47cda4", size = 3294868, upload-time = "2026-05-04T22:58:06.467Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/ac/8ac51b4a5fc5932eb7ee5c517ba7dc8cd834f0048962b6b352f00f41ebf9/cryptography-48.0.0-cp311-abi3-win_amd64.whl", hash = "sha256:5b012212e08b8dd5edc78ef54da83dd9892fd9105323b3993eff6bea65dc21d7", size = 3817107, upload-time = "2026-05-04T22:58:08.845Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/84/70e3feea9feea87fd7cbe77efb2712ae1e3e6edf10749dc6e95f4e60e455/cryptography-48.0.0-cp314-cp314t-macosx_10_9_universal2.whl", hash = "sha256:3cb07a3ed6431663cd321ea8a000a1314c74211f823e4177fefa2255e057d1ec", size = 7986556, upload-time = "2026-05-04T22:58:11.172Z" },
+    { url = "https://files.pythonhosted.org/packages/89/6e/18e07a618bb5442ba10cf4df16e99c071365528aa570dfcb8c02e25a303b/cryptography-48.0.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:8c7378637d7d88016fa6791c159f698b3d3eed28ebf844ac36b9dc04a14dae18", size = 4684776, upload-time = "2026-05-04T22:58:13.712Z" },
+    { url = "https://files.pythonhosted.org/packages/be/6a/4ea3b4c6c6759794d5ee2103c304a5076dc4b19ae1f9fe47dba439e159e9/cryptography-48.0.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:cc90c0b39b2e3c65ef52c804b72e3c58f8a04ab2a1871272798e5f9572c17d20", size = 4698121, upload-time = "2026-05-04T22:58:16.448Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/59/6ff6ad6cae03bb887da2a5860b2c9805f8dac969ef01ce563336c49bd1d1/cryptography-48.0.0-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:76341972e1eff8b4bea859f09c0d3e64b96ce931b084f9b9b7db8ef364c30eff", size = 4690042, upload-time = "2026-05-04T22:58:18.544Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/b4/fc334ed8cfd705aca282fe4d8f5ae64a8e0f74932e9feecb344610cf6e4d/cryptography-48.0.0-cp314-cp314t-manylinux_2_28_ppc64le.whl", hash = "sha256:55b7718303bf06a5753dcdccf2f3945cf18ad7bffde41b61226e4db31ab89a9c", size = 5282526, upload-time = "2026-05-04T22:58:20.75Z" },
+    { url = "https://files.pythonhosted.org/packages/11/08/9f8c5386cc4cd90d8255c7cdd0f5baf459a08502a09de30dc51f553d38dc/cryptography-48.0.0-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:a64697c641c7b1b2178e573cbc31c7c6684cd56883a478d75143dbb7118036db", size = 4733116, upload-time = "2026-05-04T22:58:23.627Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/77/99307d7574045699f8805aa500fa0fb83422d115b5400a064ddd306d7750/cryptography-48.0.0-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:561215ea3879cb1cbbf272867e2efda62476f240fb58c64de6b393ae19246741", size = 4316030, upload-time = "2026-05-04T22:58:25.581Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/36/a608b98337af3cb2aff4818e406649d30572b7031918b04c87d979495348/cryptography-48.0.0-cp314-cp314t-manylinux_2_34_aarch64.whl", hash = "sha256:ad64688338ed4bc1a6618076ba75fd7194a5f1797ac60b47afe926285adb3166", size = 4689640, upload-time = "2026-05-04T22:58:27.747Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/a6/825010a291b4438aecc1f568bc428189fc1175515223632477c07dc0a6df/cryptography-48.0.0-cp314-cp314t-manylinux_2_34_ppc64le.whl", hash = "sha256:906cbf0670286c6e0044156bc7d4af9cbb0ef6db9f73e52c3ec56ba6bdde5336", size = 5237657, upload-time = "2026-05-04T22:58:29.848Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/09/4e76a09b4caa29aad535ddc806f5d4c5d01885bd978bd984fbc6ca032cae/cryptography-48.0.0-cp314-cp314t-manylinux_2_34_x86_64.whl", hash = "sha256:ea8990436d914540a40ab24b6a77c0969695ed52f4a4874c5137ccf7045a7057", size = 4732362, upload-time = "2026-05-04T22:58:32.009Z" },
+    { url = "https://files.pythonhosted.org/packages/18/78/444fa04a77d0cb95f417dda20d450e13c56ba8e5220fc892a1658f44f882/cryptography-48.0.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:c18684a7f0cc9a3cb60328f496b8e3372def7c5d2df39ac267878b05565aaaae", size = 4819580, upload-time = "2026-05-04T22:58:34.254Z" },
+    { url = "https://files.pythonhosted.org/packages/38/85/ea67067c70a1fd4be2c63d35eeed82658023021affccc7b17705f8527dd2/cryptography-48.0.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:9be5aafa5736574f8f15f262adc81b2a9869e2cfe9014d52a44633905b40d52c", size = 4963283, upload-time = "2026-05-04T22:58:36.376Z" },
+    { url = "https://files.pythonhosted.org/packages/75/54/cc6d0f3deac3e81c7f847e8a189a12b6cdd65059b43dad25d4316abd849a/cryptography-48.0.0-cp314-cp314t-win32.whl", hash = "sha256:c17dfe85494deaeddc5ce251aebd1d60bbe6afc8b62071bb0b469431a000124f", size = 3270954, upload-time = "2026-05-04T22:58:38.791Z" },
+    { url = "https://files.pythonhosted.org/packages/49/67/cc947e288c0758a4e5473d1dcb743037ab7785541265a969240b8885441a/cryptography-48.0.0-cp314-cp314t-win_amd64.whl", hash = "sha256:27241b1dc9962e056062a8eef1991d02c3a24569c95975bd2322a8a52c6e5e12", size = 3797313, upload-time = "2026-05-04T22:58:40.746Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/63/61d4a4e1c6b6bab6ce1e213cd36a24c415d90e76d78c5eb8577c5541d2e8/cryptography-48.0.0-cp39-abi3-macosx_10_9_universal2.whl", hash = "sha256:58d00498e8933e4a194f3076aee1b4a97dfec1a6da444535755822fe5d8b0b86", size = 7983482, upload-time = "2026-05-04T22:58:43.769Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/ac/f5b5995b87770c693e2596559ffafe195b4033a57f14a82268a2842953f3/cryptography-48.0.0-cp39-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:614d0949f4790582d2cc25553abd09dd723025f0c0e7c67376a1d77196743d6e", size = 4683266, upload-time = "2026-05-04T22:58:46.064Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/c6/8b14f67e18338fbc4adb76f66c001f5c3610b3e2d1837f268f47a347dbbb/cryptography-48.0.0-cp39-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:7ce4bfae76319a532a2dc68f82cc32f5676ee792a983187dac07183690e5c66f", size = 4696228, upload-time = "2026-05-04T22:58:48.22Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/73/f808fbae9514bd91b47875b003f13e284c8c6bdfd904b7944e803937eec1/cryptography-48.0.0-cp39-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:2eb992bbd4661238c5a397594c83f5b4dc2bc5b848c365c8f991b6780efcc5c7", size = 4689097, upload-time = "2026-05-04T22:58:50.9Z" },
+    { url = "https://files.pythonhosted.org/packages/93/01/d86632d7d28db8ae83221995752eeb6639ffb374c2d22955648cf8d52797/cryptography-48.0.0-cp39-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:22a5cb272895dce158b2cacdfdc3debd299019659f42947dbdac6f32d68fe832", size = 5283582, upload-time = "2026-05-04T22:58:53.017Z" },
+    { url = "https://files.pythonhosted.org/packages/02/e1/50edc7a50334807cc4791fc4a0ce7468b4a1416d9138eab358bfc9a3d70b/cryptography-48.0.0-cp39-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:2b4d59804e8408e2fea7d1fbaf218e5ec984325221db76e6a241a9abd6cdd95c", size = 4730479, upload-time = "2026-05-04T22:58:55.611Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/af/99a582b1b1641ff5911ac559beb45097cf79efd4ead4657f578ef1af2d47/cryptography-48.0.0-cp39-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:984a20b0f62a26f48a3396c72e4bc34c66e356d356bf370053066b3b6d54634a", size = 4326481, upload-time = "2026-05-04T22:58:57.607Z" },
+    { url = "https://files.pythonhosted.org/packages/90/ee/89aa26a06ef0a7d7611788ffd571a7c50e368cc6a4d5eef8b4884e866edb/cryptography-48.0.0-cp39-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:5a5ed8fde7a1d09376ca0b40e68cd59c69fe23b1f9768bd5824f54681626032a", size = 4688713, upload-time = "2026-05-04T22:59:00.077Z" },
+    { url = "https://files.pythonhosted.org/packages/70/ba/bcb1b0bb7a33d4c7c0c4d4c7874b4a62ae4f56113a5f4baefa362dfb1f0f/cryptography-48.0.0-cp39-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:8cd666227ef7af430aa5914a9910e0ddd703e75f039cef0825cd0da71b6b711a", size = 5238165, upload-time = "2026-05-04T22:59:02.317Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/70/ca4003b1ce5ca3dc3186ada51908c8a9b9ff7d5cab83cc0d43ee14ec144f/cryptography-48.0.0-cp39-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:9071196d81abc88b3516ac8cdfad32e2b66dd4a5393a8e68a961e9161ddc6239", size = 4729947, upload-time = "2026-05-04T22:59:05.255Z" },
+    { url = "https://files.pythonhosted.org/packages/44/a0/4ec7cf774207905aef1a8d11c3750d5a1db805eb380ee4e16df317870128/cryptography-48.0.0-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:1e2d54c8be6152856a36f0882ab231e70f8ec7f14e93cf87db8a2ed056bf160c", size = 4822059, upload-time = "2026-05-04T22:59:07.802Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/75/a2e55f99c16fcac7b5d6c1eb19ad8e00799854d6be5ca845f9259eae1681/cryptography-48.0.0-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:a5da777e32ffed6f85a7b2b3f7c5cbc88c146bfcd0a1d7baf5fcc6c52ee35dd4", size = 4960575, upload-time = "2026-05-04T22:59:09.851Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/23/6e6f32143ab5d8b36ca848a502c4bcd477ae75b9e1677e3530d669062578/cryptography-48.0.0-cp39-abi3-win32.whl", hash = "sha256:77a2ccbbe917f6710e05ba9adaa25fb5075620bf3ea6fb751997875aff4ae4bd", size = 3279117, upload-time = "2026-05-04T22:59:12.019Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/9a/0fea98a70cf1749d41d738836f6349d97945f7c89433a259a6c2642eefeb/cryptography-48.0.0-cp39-abi3-win_amd64.whl", hash = "sha256:16cd65b9330583e4619939b3a3843eec1e6e789744bb01e7c7e2e62e33c239c8", size = 3792100, upload-time = "2026-05-04T22:59:14.884Z" },
 ]
 
 [[package]]
 name = "cuda-bindings"
-version = "13.2.0"
+version = "13.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "cuda-pathfinder", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/df/93/eef988860a3ca985f82c4f3174fc0cdd94e07331ba9a92e8e064c260337f/cuda_bindings-13.2.0-cp313-cp313-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6629ca2df6f795b784752409bcaedbd22a7a651b74b56a165ebc0c9dcbd504d0", size = 5614610, upload-time = "2026-03-11T00:12:50.337Z" },
-    { url = "https://files.pythonhosted.org/packages/18/23/6db3aba46864aee357ab2415135b3fe3da7e9f1fa0221fa2a86a5968099c/cuda_bindings-13.2.0-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7dca0da053d3b4cc4869eff49c61c03f3c5dbaa0bcd712317a358d5b8f3f385d", size = 6149914, upload-time = "2026-03-11T00:12:52.374Z" },
-    { url = "https://files.pythonhosted.org/packages/c0/87/87a014f045b77c6de5c8527b0757fe644417b184e5367db977236a141602/cuda_bindings-13.2.0-cp314-cp314-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a6464b30f46692d6c7f65d4a0e0450d81dd29de3afc1bb515653973d01c2cd6e", size = 5685673, upload-time = "2026-03-11T00:12:56.371Z" },
-    { url = "https://files.pythonhosted.org/packages/ee/5e/c0fe77a73aaefd3fff25ffaccaac69c5a63eafdf8b9a4c476626ef0ac703/cuda_bindings-13.2.0-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f4af9f3e1be603fa12d5ad6cfca7844c9d230befa9792b5abdf7dd79979c3626", size = 6191386, upload-time = "2026-03-11T00:12:58.965Z" },
-    { url = "https://files.pythonhosted.org/packages/5f/58/ed2c3b39c8dd5f96aa7a4abef0d47a73932c7a988e30f5fa428f00ed0da1/cuda_bindings-13.2.0-cp314-cp314t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:df850a1ff8ce1b3385257b08e47b70e959932f5f432d0a4e46a355962b4e4771", size = 5507469, upload-time = "2026-03-11T00:13:04.063Z" },
-    { url = "https://files.pythonhosted.org/packages/1f/01/0c941b112ceeb21439b05895eace78ca1aa2eaaf695c8521a068fd9b4c00/cuda_bindings-13.2.0-cp314-cp314t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e8a16384c6494e5485f39314b0b4afb04bee48d49edb16d5d8593fd35bbd231b", size = 6059693, upload-time = "2026-03-11T00:13:06.003Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/6e/2394f8163360f8391f8f1b7e72d300a82724edb81a7b7084c799fbd4c91f/cuda_bindings-13.3.1-cp313-cp313-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9efb21c1ee64981e184b9e0ba5eb3179e5ba3d4b51665a6cb52b8ef3d01a7cbf", size = 5920504, upload-time = "2026-05-29T23:11:56.883Z" },
+    { url = "https://files.pythonhosted.org/packages/34/c2/ef9b6a63f7dc432712a462c816662e662e00d38caa9b861c8c2588195d03/cuda_bindings-13.3.1-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:2732904099e0a4d4db774a5fc6d91ee95fae065b4d2ecabb4968c5fe2406c9d7", size = 6476660, upload-time = "2026-05-29T23:11:59.188Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/81/bff68ce829999c1e4209c761bbf903b1c06ec570416ddb25020864ad5907/cuda_bindings-13.3.1-cp314-cp314-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1ab2f74ed65bfef4163ba07a8db16f1085e0729291db12a2423aff84ee8278b8", size = 6013639, upload-time = "2026-05-29T23:12:03.509Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/e0/c8a1f0c8f9ffdea4f5fe6dbab89b326cef4d85caf489dad39e209da89416/cuda_bindings-13.3.1-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:efd4c814d311ec08c981f6dded1dbe7d4b371067ee4f6c14cccec4bde9590f80", size = 6534419, upload-time = "2026-05-29T23:12:05.633Z" },
+    { url = "https://files.pythonhosted.org/packages/52/b8/83b1f563925b290f2d11a01a77a84013ba56052fe3653a5bef3ccfbb43d6/cuda_bindings-13.3.1-cp314-cp314t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c3c772dfff49681541d59630c90f858e173ac926b9c593a2b7123f2a1043cc76", size = 5809771, upload-time = "2026-05-29T23:12:10.422Z" },
+    { url = "https://files.pythonhosted.org/packages/12/20/e79b4bfe98f075195afb6343d41c498f9dbd2d161d7021d4d28bceb83581/cuda_bindings-13.3.1-cp314-cp314t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:36febb7c1079d68a981dbbd8d5a67235b399802b82075c9388624719607e52b9", size = 6358584, upload-time = "2026-05-29T23:12:12.767Z" },
 ]
 
 [[package]]
 name = "cuda-pathfinder"
-version = "1.5.4"
+version = "1.5.5"
 source = { registry = "https://pypi.org/simple" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/11/d0/c177e29701cf1d3008d7d2b16b5fc626592ce13bd535f8795c5f57187e0e/cuda_pathfinder-1.5.4-py3-none-any.whl", hash = "sha256:9563d3175ce1828531acf4b94e1c1c7d67208c347ca002493e2654878b26f4b7", size = 51657, upload-time = "2026-04-27T22:42:07.712Z" },
+    { url = "https://files.pythonhosted.org/packages/11/c8/26f2e4aae92f11522a96043892ba39a90eac610d5242523aa863212bc1c7/cuda_pathfinder-1.5.5-py3-none-any.whl", hash = "sha256:0228c023f95d1480f143ef5c8922d27a2ab052087a942e81dc289c9eb8f91689", size = 51671, upload-time = "2026-05-27T01:21:25.413Z" },
 ]
 
 [[package]]
@@ -812,16 +825,16 @@ wheels = [
 
 [[package]]
 name = "databricks-sdk"
-version = "0.111.0"
+version = "0.114.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "google-auth" },
     { name = "protobuf" },
     { name = "requests" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/6e/b9/a103cc48691d9391138a0e5bf78487058de3d3d8da58b866673d05f3bd57/databricks_sdk-0.111.0.tar.gz", hash = "sha256:10a50de0709f633b13366522a9750448b0d4831d951a8ae8ee3dd2086fbe8636", size = 954398, upload-time = "2026-05-25T09:29:59.576Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/9f/1f/b11394c4439f4e1c14af91d133126396bbe3e70e9204784f58be064b749c/databricks_sdk-0.114.0.tar.gz", hash = "sha256:d62e6fcb1dc98b0b390d369261d1d68a6cf9f91139c34cf659865faf50b1d044", size = 961592, upload-time = "2026-06-02T09:33:31.302Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e3/43/33806117fc8e0992aae890be73990b31d802b66e8a423bf87b80990fce66/databricks_sdk-0.111.0-py3-none-any.whl", hash = "sha256:d14ba186afd2bea03c7157d2f03e0f861a0b8eff528cfdba926d07b9e20384b8", size = 901536, upload-time = "2026-05-25T09:29:58.057Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/f5/54a7fa8f9bb292fe1c4095731bb2cf9bbc38ebfe25abbc88657dea34d4ce/databricks_sdk-0.114.0-py3-none-any.whl", hash = "sha256:25a40b83d76fa6c8a621f884da41e45e3ae5267218dafa71db9b363dd9238f57", size = 907537, upload-time = "2026-06-02T09:33:29.541Z" },
 ]
 
 [[package]]
@@ -950,19 +963,19 @@ tracking = [{ name = "mlflow", specifier = ">=3.12.0" }]
 
 [[package]]
 name = "debugpy"
-version = "1.8.20"
+version = "1.8.21"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/e0/b7/cd8080344452e4874aae67c40d8940e2b4d47b01601a8fd9f44786c757c7/debugpy-1.8.20.tar.gz", hash = "sha256:55bc8701714969f1ab89a6d5f2f3d40c36f91b2cbe2f65d98bf8196f6a6a2c33", size = 1645207, upload-time = "2026-01-29T23:03:28.199Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/f2/aa/12037145b7a56eaa5b29b41872f7a21b538e807e13f32c4d3c46e59be084/debugpy-1.8.21.tar.gz", hash = "sha256:a3c53278e84c94e11bd87c53970ec391d1a67396c8b22609fcac576520e611a6", size = 1697577, upload-time = "2026-06-01T19:30:35.156Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/15/e2/fc500524cc6f104a9d049abc85a0a8b3f0d14c0a39b9c140511c61e5b40b/debugpy-1.8.20-cp313-cp313-macosx_15_0_universal2.whl", hash = "sha256:5dff4bb27027821fdfcc9e8f87309a28988231165147c31730128b1c983e282a", size = 2539560, upload-time = "2026-01-29T23:03:48.738Z" },
-    { url = "https://files.pythonhosted.org/packages/90/83/fb33dcea789ed6018f8da20c5a9bc9d82adc65c0c990faed43f7c955da46/debugpy-1.8.20-cp313-cp313-manylinux_2_34_x86_64.whl", hash = "sha256:84562982dd7cf5ebebfdea667ca20a064e096099997b175fe204e86817f64eaf", size = 4293272, upload-time = "2026-01-29T23:03:50.169Z" },
-    { url = "https://files.pythonhosted.org/packages/a6/25/b1e4a01bfb824d79a6af24b99ef291e24189080c93576dfd9b1a2815cd0f/debugpy-1.8.20-cp313-cp313-win32.whl", hash = "sha256:da11dea6447b2cadbf8ce2bec59ecea87cc18d2c574980f643f2d2dfe4862393", size = 5331208, upload-time = "2026-01-29T23:03:51.547Z" },
-    { url = "https://files.pythonhosted.org/packages/13/f7/a0b368ce54ffff9e9028c098bd2d28cfc5b54f9f6c186929083d4c60ba58/debugpy-1.8.20-cp313-cp313-win_amd64.whl", hash = "sha256:eb506e45943cab2efb7c6eafdd65b842f3ae779f020c82221f55aca9de135ed7", size = 5372930, upload-time = "2026-01-29T23:03:53.585Z" },
-    { url = "https://files.pythonhosted.org/packages/33/2e/f6cb9a8a13f5058f0a20fe09711a7b726232cd5a78c6a7c05b2ec726cff9/debugpy-1.8.20-cp314-cp314-macosx_15_0_universal2.whl", hash = "sha256:9c74df62fc064cd5e5eaca1353a3ef5a5d50da5eb8058fcef63106f7bebe6173", size = 2538066, upload-time = "2026-01-29T23:03:54.999Z" },
-    { url = "https://files.pythonhosted.org/packages/c5/56/6ddca50b53624e1ca3ce1d1e49ff22db46c47ea5fb4c0cc5c9b90a616364/debugpy-1.8.20-cp314-cp314-manylinux_2_34_x86_64.whl", hash = "sha256:077a7447589ee9bc1ff0cdf443566d0ecf540ac8aa7333b775ebcb8ce9f4ecad", size = 4269425, upload-time = "2026-01-29T23:03:56.518Z" },
-    { url = "https://files.pythonhosted.org/packages/c5/d9/d64199c14a0d4c476df46c82470a3ce45c8d183a6796cfb5e66533b3663c/debugpy-1.8.20-cp314-cp314-win32.whl", hash = "sha256:352036a99dd35053b37b7803f748efc456076f929c6a895556932eaf2d23b07f", size = 5331407, upload-time = "2026-01-29T23:03:58.481Z" },
-    { url = "https://files.pythonhosted.org/packages/e0/d9/1f07395b54413432624d61524dfd98c1a7c7827d2abfdb8829ac92638205/debugpy-1.8.20-cp314-cp314-win_amd64.whl", hash = "sha256:a98eec61135465b062846112e5ecf2eebb855305acc1dfbae43b72903b8ab5be", size = 5372521, upload-time = "2026-01-29T23:03:59.864Z" },
-    { url = "https://files.pythonhosted.org/packages/e0/c3/7f67dea8ccf8fdcb9c99033bbe3e90b9e7395415843accb81428c441be2d/debugpy-1.8.20-py2.py3-none-any.whl", hash = "sha256:5be9bed9ae3be00665a06acaa48f8329d2b9632f15fd09f6a9a8c8d9907e54d7", size = 5337658, upload-time = "2026-01-29T23:04:17.404Z" },
+    { url = "https://files.pythonhosted.org/packages/77/6b/d817e1f8cc77aa055d37fba092e0febfdff40fe652d8d53d4cd7a86ad98d/debugpy-1.8.21-cp313-cp313-macosx_15_0_universal2.whl", hash = "sha256:13678151fc401e2d68c9880b91e28714f797d40422994572b24560ef80910a88", size = 2477398, upload-time = "2026-06-01T19:30:57.644Z" },
+    { url = "https://files.pythonhosted.org/packages/48/57/412421516afc3055fa577516f00beec3d663f9b0ab330639547ae6c57720/debugpy-1.8.21-cp313-cp313-manylinux_2_34_x86_64.whl", hash = "sha256:ecbd158386c31ffe71d46f72d44d56e66331ab9b16cad649156d514368f23ab2", size = 3962096, upload-time = "2026-06-01T19:30:59.235Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/62/2c616337cf6ba7b07ebbc97f02c6c945a8e2f76b365e33ee809c32ee36d1/debugpy-1.8.21-cp313-cp313-win32.whl", hash = "sha256:2c2ae706dec41d99a9ca1f7ebc987a83e65578363be6f6b3ac9067504917fae1", size = 5336288, upload-time = "2026-06-01T19:31:00.79Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/99/9175103392f84c4b1bf7622888cdc68da07f0ff7d9e581266428f6776033/debugpy-1.8.21-cp313-cp313-win_amd64.whl", hash = "sha256:aa648733047443eb1d07682c4ef287d36a54507b643ffdf38b09a3ef002c72a0", size = 5376567, upload-time = "2026-06-01T19:31:02.56Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/3d/f4bbb323a548bfab2af3d6b4ffd9bf22636e55956a1285d317a1de643aad/debugpy-1.8.21-cp314-cp314-macosx_15_0_universal2.whl", hash = "sha256:9bb2a685287a2ac9b181cde89edcec64845cb51de7faaa75badb9a698bc24782", size = 2477209, upload-time = "2026-06-01T19:31:04.157Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/2d/6e7ec524984a1702777868de49a4c53202bddac2a432a76a093469587750/debugpy-1.8.21-cp314-cp314-manylinux_2_34_x86_64.whl", hash = "sha256:3d6922439bf33fd38a3e2c447869ebc7b97da5cd3d329ff1ef9bc06c4903437e", size = 3927115, upload-time = "2026-06-01T19:31:05.863Z" },
+    { url = "https://files.pythonhosted.org/packages/97/47/d1aa6d64005a98a9144647d99306b419396f9ad7bf1d73c119e17a81fb4d/debugpy-1.8.21-cp314-cp314-win32.whl", hash = "sha256:15d4963bd5ffa48f0da0947fd06757fa7621945048a14ad7705431566d3c0e7c", size = 5336724, upload-time = "2026-06-01T19:31:07.711Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/67/b905b90d163af11878c1af8abafa4a25206335e112e284e413454543a6da/debugpy-1.8.21-cp314-cp314-win_amd64.whl", hash = "sha256:fe0744a12353406de0ae8ccff0d0a4a666f00801a3db8fd04e7a5f761cd520e8", size = 5373803, upload-time = "2026-06-01T19:31:09.469Z" },
+    { url = "https://files.pythonhosted.org/packages/95/51/67e7cf11a53e40694f720457d5b3a1cdaaa3d5a9a633e482f225456b93ff/debugpy-1.8.21-py2.py3-none-any.whl", hash = "sha256:b1e37d333663c8851516a47364ef473da127f9caebe4417e6df6f5825a7e9a92", size = 5352888, upload-time = "2026-06-01T19:31:25.186Z" },
 ]
 
 [[package]]
@@ -985,11 +998,11 @@ wheels = [
 
 [[package]]
 name = "distlib"
-version = "0.4.0"
+version = "0.4.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/96/8e/709914eb2b5749865801041647dc7f4e6d00b549cfe88b65ca192995f07c/distlib-0.4.0.tar.gz", hash = "sha256:feec40075be03a04501a973d81f633735b4b69f98b05450592310c0f401a4e0d", size = 614605, upload-time = "2025-07-17T16:52:00.465Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/86/b2/d6fc3f2347f43dada79e5ff118493e8109c98400a0e29a1d5264a3aa479b/distlib-0.4.1.tar.gz", hash = "sha256:c3804d0d2d4b5fcd44036eb860cb6660485fcdf5c2aba53dc324d805837ea65b", size = 610526, upload-time = "2026-06-02T11:17:40.691Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/33/6b/e0547afaf41bf2c42e52430072fa5658766e3d65bd4b03a563d1b6336f57/distlib-0.4.0-py2.py3-none-any.whl", hash = "sha256:9659f7d87e46584a30b5780e43ac7a2143098441670ff0a49d5f9034c54a6c16", size = 469047, upload-time = "2025-07-17T16:51:58.613Z" },
+    { url = "https://files.pythonhosted.org/packages/25/18/3497c4fa83a76dcb154923fd2075522e8dd6995ecee4093c00ae18160046/distlib-0.4.1-py2.py3-none-any.whl", hash = "sha256:9c2c552c68cbadc619f2d0ed3a69e27c351a3f4c9baa9ffb7df9e9cdc3d19a97", size = 469216, upload-time = "2026-06-02T11:17:38.779Z" },
 ]
 
 [[package]]
@@ -1055,11 +1068,11 @@ wheels = [
 
 [[package]]
 name = "filelock"
-version = "3.29.0"
+version = "3.29.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/b5/fe/997687a931ab51049acce6fa1f23e8f01216374ea81374ddee763c493db5/filelock-3.29.0.tar.gz", hash = "sha256:69974355e960702e789734cb4871f884ea6fe50bd8404051a3530bc07809cf90", size = 57571, upload-time = "2026-04-19T15:39:10.068Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/1f/f9/f38573ed5844586db374d085911740a501ccfa373b455fc9413f09f85237/filelock-3.29.1.tar.gz", hash = "sha256:d97e6b1b9757569626c58caa07dc4beb1613f4a2938b1e8cc81afca398906c9e", size = 59335, upload-time = "2026-06-03T15:19:04.053Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/81/47/dd9a212ef6e343a6857485ffe25bba537304f1913bdbed446a23f7f592e1/filelock-3.29.0-py3-none-any.whl", hash = "sha256:96f5f6344709aa1572bbf631c640e4ebeeb519e08da902c39a001882f30ac258", size = 39812, upload-time = "2026-04-19T15:39:08.752Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/a0/614c5fe402fd88951df45f4dda2fa3b4e17a99ecd92340771929169b3b95/filelock-3.29.1-py3-none-any.whl", hash = "sha256:85199dfd706869641b72b2e8955d5416a4b2b7dc4b0e8e6d97b4cc1299a6983b", size = 40750, upload-time = "2026-06-03T15:19:02.959Z" },
 ]
 
 [[package]]
@@ -1245,7 +1258,7 @@ wheels = [
 
 [[package]]
 name = "google-api-core"
-version = "2.30.3"
+version = "2.31.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "google-auth" },
@@ -1254,9 +1267,9 @@ dependencies = [
     { name = "protobuf" },
     { name = "requests" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/16/ce/502a57fb0ec752026d24df1280b162294b22a0afb98a326084f9a979138b/google_api_core-2.30.3.tar.gz", hash = "sha256:e601a37f148585319b26db36e219df68c5d07b6382cff2d580e83404e44d641b", size = 177001, upload-time = "2026-04-10T00:41:28.035Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c6/22/155cadf1d49272a9cf48f3168c0f3874fa13397297e611a5ea00cd093880/google_api_core-2.31.0.tar.gz", hash = "sha256:2be84ee0f584c48e6bde1b36766e23348b361fb7e55e56135fc76ce1c397f9c2", size = 176492, upload-time = "2026-06-03T14:52:17.257Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/03/15/e56f351cf6ef1cfea58e6ac226a7318ed1deb2218c4b3cc9bd9e4b786c5a/google_api_core-2.30.3-py3-none-any.whl", hash = "sha256:a85761ba72c444dad5d611c2220633480b2b6be2521eca69cca2dbb3ffd6bfe8", size = 173274, upload-time = "2026-04-09T22:57:16.198Z" },
+    { url = "https://files.pythonhosted.org/packages/86/40/9bdbb60b03a332bd45acb8703da08bbc27d991d35286b62e42acc86d243a/google_api_core-2.31.0-py3-none-any.whl", hash = "sha256:ef79fb3784c71cbac89cbd03301ba0c8fb8ad2aa95d7f9204dd9628f7adf59ab", size = 173102, upload-time = "2026-06-03T14:51:26.729Z" },
 ]
 
 [package.optional-dependencies]
@@ -1311,7 +1324,7 @@ wheels = [
 
 [[package]]
 name = "google-cloud-storage"
-version = "3.10.1"
+version = "3.11.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "google-api-core" },
@@ -1321,9 +1334,9 @@ dependencies = [
     { name = "google-resumable-media" },
     { name = "requests" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/4c/47/205eb8e9a1739b5345843e5a425775cbdc472cc38e7eda082ba5b8d02450/google_cloud_storage-3.10.1.tar.gz", hash = "sha256:97db9aa4460727982040edd2bd13ff3d5e2260b5331ad22895802da1fc2a5286", size = 17309950, upload-time = "2026-03-23T09:35:23.409Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/22/09/8953e2993e604c8882fd441b5b2de624a2dfe7e6144c6166d7b477509596/google_cloud_storage-3.11.0.tar.gz", hash = "sha256:498bf37c999028f69a245f586b5e50d89f59df1fafc0e3a93783ac56be2a456b", size = 17335639, upload-time = "2026-06-03T16:14:04.649Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ad/ff/ca9ab2417fa913d75aae38bf40bf856bb2749a604b2e0f701b37cfcd23cc/google_cloud_storage-3.10.1-py3-none-any.whl", hash = "sha256:a72f656759b7b99bda700f901adcb3425a828d4a29f911bc26b3ea79c5b1217f", size = 324453, upload-time = "2026-03-23T09:35:21.368Z" },
+    { url = "https://files.pythonhosted.org/packages/09/7e/ee0dd1a67ac75d29d0c438969d85d4fadbc4bcab47b0a8ccfa7eb22f643c/google_cloud_storage-3.11.0-py3-none-any.whl", hash = "sha256:cfcc33aa6b899ec9dd1771286f8e79fbed5c35c1c174718071b079aa827f37c2", size = 339654, upload-time = "2026-06-03T16:12:46.052Z" },
 ]
 
 [[package]]
@@ -1346,14 +1359,14 @@ wheels = [
 
 [[package]]
 name = "google-resumable-media"
-version = "2.9.0"
+version = "2.10.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "google-crc32c" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/00/4b/0b235beccc310d0a48adbc7246b719d173cca6c88c572dfa4b090e39143c/google_resumable_media-2.9.0.tar.gz", hash = "sha256:f7cfb224846a9dd444d125115dfbe8ef02a2b893e78f087762fe716a255a734b", size = 2164534, upload-time = "2026-05-07T08:04:44.236Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/48/f8/1ca5781d6be9cb9f73f7d40f4958c4bd1226a60598e3e39e1d6aaf838c4b/google_resumable_media-2.10.0.tar.gz", hash = "sha256:e324bc9d0fdae4c52a08ae90456edc4e71ece858399e1217ac0eb3a51d6bc6ee", size = 2164570, upload-time = "2026-06-03T16:14:26.103Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/07/73/3518e63deb1667c5409a4579e28daf5e84479a87a72c547e0487f7883dcd/google_resumable_media-2.9.0-py3-none-any.whl", hash = "sha256:c8901e88e389af8bed64d9696c74d8bad961865eb2236e13e0bfca9bb0a65ca3", size = 81507, upload-time = "2026-05-07T08:03:23.809Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/d8/00c6854ac1512bb9eaf13bd3f8f28222f7674947fc510a4ff7616f2efc80/google_resumable_media-2.10.0-py3-none-any.whl", hash = "sha256:88152884bee37b2bf36a0ab81ad8c7fd12212c9803dd981d77c1b35b02d34e7c", size = 81533, upload-time = "2026-06-03T16:13:12.51Z" },
 ]
 
 [[package]]
@@ -1462,59 +1475,59 @@ wheels = [
 
 [[package]]
 name = "grpcio"
-version = "1.80.0"
+version = "1.81.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/b7/48/af6173dbca4454f4637a4678b67f52ca7e0c1ed7d5894d89d434fecede05/grpcio-1.80.0.tar.gz", hash = "sha256:29aca15edd0688c22ba01d7cc01cb000d72b2033f4a3c72a81a19b56fd143257", size = 12978905, upload-time = "2026-03-30T08:49:10.502Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/15/f3/23f47b24f8d8c2028eba501db3acfbb2f592cbb5995eaa6e363a627b74d7/grpcio-1.81.0.tar.gz", hash = "sha256:a5acd7efd3b1fe9b4eb0bcaaa1507eed68a0ad0678b654c3f7b464df9ba9dca5", size = 13032272, upload-time = "2026-06-01T05:56:22.827Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/2f/3a/7c3c25789e3f069e581dc342e03613c5b1cb012c4e8c7d9d5cf960a75856/grpcio-1.80.0-cp313-cp313-linux_armv7l.whl", hash = "sha256:e9e408fc016dffd20661f0126c53d8a31c2821b5c13c5d67a0f5ed5de93319ad", size = 6017243, upload-time = "2026-03-30T08:47:40.075Z" },
-    { url = "https://files.pythonhosted.org/packages/04/19/21a9806eb8240e174fd1ab0cd5b9aa948bb0e05c2f2f55f9d5d7405e6d08/grpcio-1.80.0-cp313-cp313-macosx_11_0_universal2.whl", hash = "sha256:92d787312e613754d4d8b9ca6d3297e69994a7912a32fa38c4c4e01c272974b0", size = 12010840, upload-time = "2026-03-30T08:47:43.11Z" },
-    { url = "https://files.pythonhosted.org/packages/18/3a/23347d35f76f639e807fb7a36fad3068aed100996849a33809591f26eca6/grpcio-1.80.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:8ac393b58aa16991a2f1144ec578084d544038c12242da3a215966b512904d0f", size = 6567644, upload-time = "2026-03-30T08:47:46.806Z" },
-    { url = "https://files.pythonhosted.org/packages/ff/40/96e07ecb604a6a67ae6ab151e3e35b132875d98bc68ec65f3e5ab3e781d7/grpcio-1.80.0-cp313-cp313-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:68e5851ac4b9afe07e7f84483803ad167852570d65326b34d54ca560bfa53fb6", size = 7277830, upload-time = "2026-03-30T08:47:49.643Z" },
-    { url = "https://files.pythonhosted.org/packages/9b/e2/da1506ecea1f34a5e365964644b35edef53803052b763ca214ba3870c856/grpcio-1.80.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:873ff5d17d68992ef6605330127425d2fc4e77e612fa3c3e0ed4e668685e3140", size = 6783216, upload-time = "2026-03-30T08:47:52.817Z" },
-    { url = "https://files.pythonhosted.org/packages/44/83/3b20ff58d0c3b7f6caaa3af9a4174d4023701df40a3f39f7f1c8e7c48f9d/grpcio-1.80.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:2bea16af2750fd0a899bf1abd9022244418b55d1f37da2202249ba4ba673838d", size = 7385866, upload-time = "2026-03-30T08:47:55.687Z" },
-    { url = "https://files.pythonhosted.org/packages/47/45/55c507599c5520416de5eefecc927d6a0d7af55e91cfffb2e410607e5744/grpcio-1.80.0-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:ba0db34f7e1d803a878284cd70e4c63cb6ae2510ba51937bf8f45ba997cefcf7", size = 8391602, upload-time = "2026-03-30T08:47:58.303Z" },
-    { url = "https://files.pythonhosted.org/packages/10/bb/dd06f4c24c01db9cf11341b547d0a016b2c90ed7dbbb086a5710df7dd1d7/grpcio-1.80.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:8eb613f02d34721f1acf3626dfdb3545bd3c8505b0e52bf8b5710a28d02e8aa7", size = 7826752, upload-time = "2026-03-30T08:48:01.311Z" },
-    { url = "https://files.pythonhosted.org/packages/f9/1e/9d67992ba23371fd63d4527096eb8c6b76d74d52b500df992a3343fd7251/grpcio-1.80.0-cp313-cp313-win32.whl", hash = "sha256:93b6f823810720912fd131f561f91f5fed0fda372b6b7028a2681b8194d5d294", size = 4142310, upload-time = "2026-03-30T08:48:04.594Z" },
-    { url = "https://files.pythonhosted.org/packages/cf/e6/283326a27da9e2c3038bc93eeea36fb118ce0b2d03922a9cda6688f53c5b/grpcio-1.80.0-cp313-cp313-win_amd64.whl", hash = "sha256:e172cf795a3ba5246d3529e4d34c53db70e888fa582a8ffebd2e6e48bc0cba50", size = 4882833, upload-time = "2026-03-30T08:48:07.363Z" },
-    { url = "https://files.pythonhosted.org/packages/c5/6d/e65307ce20f5a09244ba9e9d8476e99fb039de7154f37fb85f26978b59c3/grpcio-1.80.0-cp314-cp314-linux_armv7l.whl", hash = "sha256:3d4147a97c8344d065d01bbf8b6acec2cf86fb0400d40696c8bdad34a64ffc0e", size = 6017376, upload-time = "2026-03-30T08:48:10.005Z" },
-    { url = "https://files.pythonhosted.org/packages/69/10/9cef5d9650c72625a699c549940f0abb3c4bfdb5ed45a5ce431f92f31806/grpcio-1.80.0-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:d8e11f167935b3eb089ac9038e1a063e6d7dbe995c0bb4a661e614583352e76f", size = 12018133, upload-time = "2026-03-30T08:48:12.927Z" },
-    { url = "https://files.pythonhosted.org/packages/04/82/983aabaad82ba26113caceeb9091706a0696b25da004fe3defb5b346e15b/grpcio-1.80.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:f14b618fc30de822681ee986cfdcc2d9327229dc4c98aed16896761cacd468b9", size = 6574748, upload-time = "2026-03-30T08:48:16.386Z" },
-    { url = "https://files.pythonhosted.org/packages/07/d7/031666ef155aa0bf399ed7e19439656c38bbd143779ae0861b038ce82abd/grpcio-1.80.0-cp314-cp314-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:4ed39fbdcf9b87370f6e8df4e39ca7b38b3e5e9d1b0013c7b6be9639d6578d14", size = 7277711, upload-time = "2026-03-30T08:48:19.627Z" },
-    { url = "https://files.pythonhosted.org/packages/e8/43/f437a78f7f4f1d311804189e8f11fb311a01049b2e08557c1068d470cb2e/grpcio-1.80.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:2dcc70e9f0ba987526e8e8603a610fb4f460e42899e74e7a518bf3c68fe1bf05", size = 6785372, upload-time = "2026-03-30T08:48:22.373Z" },
-    { url = "https://files.pythonhosted.org/packages/93/3d/f6558e9c6296cb4227faa5c43c54a34c68d32654b829f53288313d16a86e/grpcio-1.80.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:448c884b668b868562b1bda833c5fce6272d26e1926ec46747cda05741d302c1", size = 7395268, upload-time = "2026-03-30T08:48:25.638Z" },
-    { url = "https://files.pythonhosted.org/packages/06/21/0fdd77e84720b08843c371a2efa6f2e19dbebf56adc72df73d891f5506f0/grpcio-1.80.0-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:a1dc80fe55685b4a543555e6eef975303b36c8db1023b1599b094b92aa77965f", size = 8392000, upload-time = "2026-03-30T08:48:28.974Z" },
-    { url = "https://files.pythonhosted.org/packages/f5/68/67f4947ed55d2e69f2cc199ab9fd85e0a0034d813bbeef84df6d2ba4d4b7/grpcio-1.80.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:31b9ac4ad1aa28ffee5503821fafd09e4da0a261ce1c1281c6c8da0423c83b6e", size = 7828477, upload-time = "2026-03-30T08:48:32.054Z" },
-    { url = "https://files.pythonhosted.org/packages/44/b6/8d4096691b2e385e8271911a0de4f35f0a6c7d05aff7098e296c3de86939/grpcio-1.80.0-cp314-cp314-win32.whl", hash = "sha256:367ce30ba67d05e0592470428f0ec1c31714cab9ef19b8f2e37be1f4c7d32fae", size = 4218563, upload-time = "2026-03-30T08:48:34.538Z" },
-    { url = "https://files.pythonhosted.org/packages/e5/8c/bbe6baf2557262834f2070cf668515fa308b2d38a4bbf771f8f7872a7036/grpcio-1.80.0-cp314-cp314-win_amd64.whl", hash = "sha256:3b01e1f5464c583d2f567b2e46ff0d516ef979978f72091fd81f5ab7fa6e2e7f", size = 5019457, upload-time = "2026-03-30T08:48:37.308Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/29/779ee53c931d0fd55c1d459fde43e485172caa3ac87cbd43d003a13a0185/grpcio-1.81.0-cp313-cp313-linux_armv7l.whl", hash = "sha256:62bbe463c9f0f2ff24e31bd25f8dd8b4bae78900e315915a3195a0ef1471a855", size = 6054973, upload-time = "2026-06-01T05:55:25.043Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/b6/7211807926b5a17f8d9a5d47c739a163d6812fefe3e4714e81cf92945ed7/grpcio-1.81.0-cp313-cp313-macosx_11_0_universal2.whl", hash = "sha256:43c121e135ae44d1559b430db2b2dfad7421cbbe40e1deba506c7dc62b439719", size = 12048662, upload-time = "2026-06-01T05:55:28.453Z" },
+    { url = "https://files.pythonhosted.org/packages/64/89/b1b93ef6b34bd20bbaf707fa99133bc9cc302139d5ec6f77a165c7169796/grpcio-1.81.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:f345de40ef2e65f63645d53d251824e6070e07804827c5b00ec2e44555f9f901", size = 6599116, upload-time = "2026-06-01T05:55:31.185Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/bc/c89f9b9d1c22895715356a1e009554dae66319e97826bb4d30bcda7d29e8/grpcio-1.81.0-cp313-cp313-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:8c0855a350886f713b9e458e2a10d208009dcaa849f574e39cd6067db1fe1279", size = 7307591, upload-time = "2026-06-01T05:55:33.463Z" },
+    { url = "https://files.pythonhosted.org/packages/65/4a/1df2a4cb4a1386e066ab7e4175e34bb884b35ccb60d3621c09c84af6aabb/grpcio-1.81.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:a524cd530900bd24511fcb7f2ed144da4ea37711c4b094475d0bceca7a93a170", size = 6811797, upload-time = "2026-06-01T05:55:36.731Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/dc/fa189d20601a1be25b08850cfb733879bbb1047b62a8feec3a60e3e1a87b/grpcio-1.81.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:e7746ba3e6efc9e2b748eff59470a2b8684d5a9ec607c6580bcaa5be175820bc", size = 7415131, upload-time = "2026-06-01T05:55:39.451Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/a3/5625c48cb48d23c6631b3e5294f88e4c751f22a52591ae78859fab96dca1/grpcio-1.81.0-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:aaaa4f7f2057d795952e4eacf3f342be8b5b156992f6ac85023c8b98794ebd47", size = 8408398, upload-time = "2026-06-01T05:55:42.219Z" },
+    { url = "https://files.pythonhosted.org/packages/75/34/0f8202c6809a46c2b4d69125ef3667c40b1c211f8e19930e5fa1f1197039/grpcio-1.81.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:0fba53cb96004b2b7fb758b46b2288cb49d0b658316a4e73f3ef67230616ee65", size = 7844481, upload-time = "2026-06-01T05:55:44.849Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/95/c3366b5b5edf4c4adc90f2e29ca16e57965a8e56dc8d2ee89565ba1905bb/grpcio-1.81.0-cp313-cp313-win32.whl", hash = "sha256:c197e2ef75a442528072b29e9755da299110e8610e8bcbb59a6b4cf55384f005", size = 4182777, upload-time = "2026-06-01T05:55:47.459Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/a7/932f2f748511a32e641a2aba0d30dded3ed6e8bc330e0924e4d5d86853e6/grpcio-1.81.0-cp313-cp313-win_amd64.whl", hash = "sha256:194eddfacc84d80f50512e9fd4ee851d5f2499f18f299c95aa8fb4748f0537e0", size = 4928085, upload-time = "2026-06-01T05:55:50.158Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/1d/28b231333857deb840bc3d182ae087510170ea6d68f21393aeb0fe499530/grpcio-1.81.0-cp314-cp314-linux_armv7l.whl", hash = "sha256:a9351055f52660b58f3d4890ea66188b5134399f82b11aa0c55bd4b99eff5390", size = 6055712, upload-time = "2026-06-01T05:55:52.889Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/b8/999c14f9dff0fc47549d2e827cba1343ddc18e1d1bf0d06d2cf628eecbd9/grpcio-1.81.0-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:300f3337b6425fd16ead9a4f9b2ac25801acb64aa5bc0b99eb69901645b2b1d2", size = 12057189, upload-time = "2026-06-01T05:55:55.952Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/3d/1fbde079572562af65351151d840525a13879eb7b481d35b55cd64c6127a/grpcio-1.81.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:97bbd623f7ded558fd4f7cb5a4f600c4d4de65c5dd364c83a5b14b2a10a2d3b5", size = 6608136, upload-time = "2026-06-01T05:55:59.069Z" },
+    { url = "https://files.pythonhosted.org/packages/32/89/1f17cb6882abfd8e5a303a25d5d1665abef5a8c499a96198c65a651d1b85/grpcio-1.81.0-cp314-cp314-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:ff83d889e3ebf6341c8c7864ad8031591ad5ca61599072fc511644d1eb962d2b", size = 7307045, upload-time = "2026-06-01T05:56:02.376Z" },
+    { url = "https://files.pythonhosted.org/packages/48/5a/f98e91b2e755652e637ea2144318b0229b290062199f761b445fe1fa6015/grpcio-1.81.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:c4fe218c5a35e1d87a5a26544237f1fa41dfd9cbd3c856b0810a30061f8b0aaf", size = 6812794, upload-time = "2026-06-01T05:56:05.777Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/0c/77892d715ac41e7ec0ace2a50080ffb64e189188056f607a66fe0014d1ee/grpcio-1.81.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:b8b025b6af43ee0ad4a70307025d77bcab5adde7c4597786010d802c203e9fc5", size = 7422767, upload-time = "2026-06-01T05:56:08.524Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/b8/aa04590c6564714d94954515f15a236e59d4b9b3ad01e615f1b706d7792d/grpcio-1.81.0-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:3d4e0ce5a40a998cf608c8ba60ecfe18fdf364a9aa193ae4ac3faeecd0e86757", size = 8408551, upload-time = "2026-06-01T05:56:11.283Z" },
+    { url = "https://files.pythonhosted.org/packages/43/3d/4f4a3450a1973568910c6909cb74abbf2126f68aefae5976962f9f7ad50d/grpcio-1.81.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:aa948712c8e5fa40ec250870bda14bc7578e1bb832a8912d9d2a0f720518edbe", size = 7846468, upload-time = "2026-06-01T05:56:14.536Z" },
+    { url = "https://files.pythonhosted.org/packages/88/f4/5827fd248221ad3b44161c23ce9b5f4ee405b04fc6da5fd402a9aa87a84a/grpcio-1.81.0-cp314-cp314-win32.whl", hash = "sha256:fbbe81314a9d92156abce8b62c09364eb8bafc0ca2a19919a45ec64b5c6cb664", size = 4264427, upload-time = "2026-06-01T05:56:17.192Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/e8/127dc2b246096ad50ef7c8d9b7b31d757787aeb796368bcdd4454e4204c4/grpcio-1.81.0-cp314-cp314-win_amd64.whl", hash = "sha256:b93cee313cae4e113fbb3a0ce1ea5633db6f63cfde2b2dc1d817429026b2a50b", size = 5070848, upload-time = "2026-06-01T05:56:19.735Z" },
 ]
 
 [[package]]
 name = "grpcio-status"
-version = "1.80.0"
+version = "1.81.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "googleapis-common-protos" },
     { name = "grpcio" },
     { name = "protobuf" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/b1/ed/105f619bdd00cb47a49aa2feea6232ea2bbb04199d52a22cc6a7d603b5cb/grpcio_status-1.80.0.tar.gz", hash = "sha256:df73802a4c89a3ea88aa2aff971e886fccce162bc2e6511408b3d67a144381cd", size = 13901, upload-time = "2026-03-30T08:54:34.784Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/01/b6/cdc177114997d15c887fb09ccfd16705c8ceb8b4ca2487902b54a7bfd1af/grpcio_status-1.81.0.tar.gz", hash = "sha256:b6fe9788cfdd1f0f63c0528a1e0bfdb41e8ff0583e920d2d8e8888598c01bb69", size = 13900, upload-time = "2026-06-01T06:00:32.638Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/76/80/58cd2dfc19a07d022abe44bde7c365627f6c7cb6f692ada6c65ca437d09a/grpcio_status-1.80.0-py3-none-any.whl", hash = "sha256:4b56990363af50dbf2c2ebb80f1967185c07d87aa25aa2bea45ddb75fc181dbe", size = 14638, upload-time = "2026-03-30T08:54:01.569Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/b7/5aa346bf1cdecd4ed64b86c10a4d5a089ce3da89145f8328caf0b22b240d/grpcio_status-1.81.0-py3-none-any.whl", hash = "sha256:10eb4c2309db902dc26c1873e80a821bf794be772c10dfd83030f7f59f165fab", size = 14634, upload-time = "2026-06-01T06:00:13.345Z" },
 ]
 
 [[package]]
 name = "gunicorn"
-version = "25.3.0"
+version = "26.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "packaging", marker = "sys_platform != 'win32'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c4/f4/e78fa054248fab913e2eab0332c6c2cb07421fca1ce56d8fe43b6aef57a4/gunicorn-25.3.0.tar.gz", hash = "sha256:f74e1b2f9f76f6cd1ca01198968bd2dd65830edc24b6e8e4d78de8320e2fe889", size = 634883, upload-time = "2026-03-27T00:00:26.092Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/6d/b7/a4a3f632f823e432ce6bc65f62961b7980c898c77f075a2f7118cb3846fe/gunicorn-26.0.0.tar.gz", hash = "sha256:ca9346f85e3a4aeeb64d491045c16b9a35647abd37ea15efe53080eb8b090baf", size = 727286, upload-time = "2026-05-05T06:38:25.529Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/43/c8/8aaf447698c4d59aa853fd318eed300b5c9e44459f242ab8ead6c9c09792/gunicorn-25.3.0-py3-none-any.whl", hash = "sha256:cacea387dab08cd6776501621c295a904fe8e3b7aae9a1a3cbb26f4e7ed54660", size = 208403, upload-time = "2026-03-27T00:00:27.386Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/40/9c2384fc2be4ad25dd4a49decd5ad9ea5a3639814c11bd40ab77cb9f0a14/gunicorn-26.0.0-py3-none-any.whl", hash = "sha256:40233d26a5f0d1872916188c276e21641155111c2853f0c2cd55260aec0d24fc", size = 212009, upload-time = "2026-05-05T06:38:23.007Z" },
 ]
 
 [[package]]
@@ -1573,49 +1586,52 @@ wheels = [
 
 [[package]]
 name = "hiredis"
-version = "3.3.1"
+version = "3.4.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/97/d6/9bef6dc3052c168c93fbf7e6c0f2b12c45f0f741a2d30fd919096774343a/hiredis-3.3.1.tar.gz", hash = "sha256:da6f0302360e99d32bc2869772692797ebadd536e1b826d0103c72ba49d38698", size = 89101, upload-time = "2026-03-16T15:21:08.092Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/1f/e2/1654d65851f39fd94e91a77a5655d09d4b64901fdc594020d8348db697b2/hiredis-3.4.0.tar.gz", hash = "sha256:da19331354433af6a2c54c21f2d70ba084933c0d7d2c43578ec5c5b446674ad5", size = 137169, upload-time = "2026-06-03T16:23:46.226Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d8/4b/c7f4d6d6643622f296395269e24b02c69d4ac72822f052b8cae16fa3af03/hiredis-3.3.1-cp313-cp313-macosx_10_15_universal2.whl", hash = "sha256:afe3c3863f16704fb5d7c2c6ff56aaf9e054f6d269f7b4c9074c5476178d1aba", size = 82027, upload-time = "2026-03-16T15:19:48.002Z" },
-    { url = "https://files.pythonhosted.org/packages/9b/45/198be960a7443d6eb5045751e929480929c0defbca316ce1a47d15187330/hiredis-3.3.1-cp313-cp313-macosx_10_15_x86_64.whl", hash = "sha256:f19ee7dc1ef8a6497570d91fa4057ba910ad98297a50b8c44ff37589f7c89d17", size = 46220, upload-time = "2026-03-16T15:19:48.953Z" },
-    { url = "https://files.pythonhosted.org/packages/6a/a4/6ab925177f289830008dbe1488a9858675e2e234f48c9c1653bd4d0eaddc/hiredis-3.3.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:09f5e510f637f2c72d2a79fb3ad05f7b6211e057e367ca5c4f97bb3d8c9d71f4", size = 41858, upload-time = "2026-03-16T15:19:49.939Z" },
-    { url = "https://files.pythonhosted.org/packages/fe/c8/a0ddbb9e9c27fcb0022f7b7e93abc75727cb634c6a5273ca5171033dac78/hiredis-3.3.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1b46e96b50dad03495447860510daebd2c96fd44ed25ba8ccb03e9f89eaa9d34", size = 170095, upload-time = "2026-03-16T15:19:51.216Z" },
-    { url = "https://files.pythonhosted.org/packages/94/06/618d509cc454912028f71995f3dd6eb54606f0aa8163ff79c5b7ec1f2bda/hiredis-3.3.1-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:b4fe7f38aa8956fcc1cea270e62601e0e11066aff78e384be70fd283d30293b6", size = 181745, upload-time = "2026-03-16T15:19:52.72Z" },
-    { url = "https://files.pythonhosted.org/packages/06/14/75b2deb62a61fc75a41ce1a6a781fe239133bbc88fef404d32a148ad152a/hiredis-3.3.1-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:2b96da7e365d6488d2a75266a662cbe3cc14b28c23dd9b0c9aa04b5bc5c20192", size = 180465, upload-time = "2026-03-16T15:19:53.847Z" },
-    { url = "https://files.pythonhosted.org/packages/7e/8c/8e03dcbfde8e2ca3f880fce06ad0877b3f098ed5fdfb17cf3b821a32323a/hiredis-3.3.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:52d5641027d6731bc7b5e7d126a5158a99784a9f8c6de3d97ca89aca4969e9f8", size = 172419, upload-time = "2026-03-16T15:19:54.959Z" },
-    { url = "https://files.pythonhosted.org/packages/03/05/843005d68403a3805309075efc6638360a3ababa6cb4545163bf80c8e7f7/hiredis-3.3.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:eddeb9a153795cf6e615f9f3cef66a1d573ff3b6ee16df2b10d1d1c2f2baeaa8", size = 166398, upload-time = "2026-03-16T15:19:56.36Z" },
-    { url = "https://files.pythonhosted.org/packages/f5/23/abe2476244fd792f5108009ec0ae666eaa5b2165ca19f2e86638d8324ac9/hiredis-3.3.1-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:011a9071c3df4885cac7f58a2623feac6c8e2ad30e6ba93c55195af05ce61ff5", size = 176844, upload-time = "2026-03-16T15:19:57.462Z" },
-    { url = "https://files.pythonhosted.org/packages/c6/47/e1cdccc559b98e548bcff0868c3938d375663418c0adca465895ee1f72e7/hiredis-3.3.1-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:264ee7e9cb6c30dc78da4ecf71d74cf14ca122817c665d838eda8b4384bce1b0", size = 170366, upload-time = "2026-03-16T15:19:58.548Z" },
-    { url = "https://files.pythonhosted.org/packages/a2/e1/fda8325f51d06877e8e92500b15d4aff3855b4c3c91dbd9636a82e4591f2/hiredis-3.3.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:6d1434d0bcc1b3ef048bae53f26456405c08aeed9827e65b24094f5f3a6793f1", size = 168023, upload-time = "2026-03-16T15:19:59.727Z" },
-    { url = "https://files.pythonhosted.org/packages/cd/21/2839d1625095989c116470e2b6841bbe1a2a5509585e82a4f3f5cd47f511/hiredis-3.3.1-cp313-cp313-win32.whl", hash = "sha256:f915a34fb742e23d0d61573349aa45d6f74037fde9d58a9f340435eff8d62736", size = 20535, upload-time = "2026-03-16T15:20:00.938Z" },
-    { url = "https://files.pythonhosted.org/packages/84/f9/534c2a89b24445a9a9623beb4697fd72b8c8f16286f6f3bda012c7af004a/hiredis-3.3.1-cp313-cp313-win_amd64.whl", hash = "sha256:d8e56e0d1fe607bfff422633f313aec9191c3859ab99d11ff097e3e6e068000c", size = 22383, upload-time = "2026-03-16T15:20:01.865Z" },
-    { url = "https://files.pythonhosted.org/packages/03/72/0450d6b449da58120c5497346eb707738f8f67b9e60c28a8ef90133fc81f/hiredis-3.3.1-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:439f9a5cc8f9519ce208a24cdebfa0440fef26aa682a40ba2c92acb10a53f5e0", size = 82112, upload-time = "2026-03-16T15:20:02.865Z" },
-    { url = "https://files.pythonhosted.org/packages/22/c0/0be33a29bcd463e6cbb0282515dd4d0cdfe33c30c7afc6d4d8c460e23266/hiredis-3.3.1-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:3724f0e58c6ff76fd683429945491de71324ab1bc0ad943a8d68cb0932d24075", size = 46238, upload-time = "2026-03-16T15:20:03.896Z" },
-    { url = "https://files.pythonhosted.org/packages/62/f2/f999854bfaf3bcbee0f797f24706c182ecfaca825f6a582f6281a6aa97e0/hiredis-3.3.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:29fe35e3c6fe03204e75c86514f452591957a1e06b05d86e10d795455b71c355", size = 41891, upload-time = "2026-03-16T15:20:04.939Z" },
-    { url = "https://files.pythonhosted.org/packages/f2/c8/cd9ab90fec3a301d864d8ab6167aea387add8e2287969d89cbcd45d6b0e0/hiredis-3.3.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d42f3a13290f89191568fc113d95a3d2c8759cdd8c3672f021d8b7436f909e75", size = 170485, upload-time = "2026-03-16T15:20:06.284Z" },
-    { url = "https://files.pythonhosted.org/packages/ac/9a/1ddf9ea236a292963146cbaf6722abeb9d503ca47d821267bb8b3b81c4f7/hiredis-3.3.1-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:2afc675b831f7552da41116fffffca4340f387dc03f56d6ec0c7895ab0b59a10", size = 182030, upload-time = "2026-03-16T15:20:07.857Z" },
-    { url = "https://files.pythonhosted.org/packages/d4/b8/e070a1dbf8a1bbb8814baa0b00836fbe3f10c7af8e11f942cc739c64e062/hiredis-3.3.1-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:4106201cd052d9eabe3cb7b5a24b0fe37307792bda4fcb3cf6ddd72f697828e8", size = 180543, upload-time = "2026-03-16T15:20:09.096Z" },
-    { url = "https://files.pythonhosted.org/packages/0d/bb/b5f4f98e44626e2446cd8a52ce6cb1fc1c99786b6e2db3bf09cea97b90cd/hiredis-3.3.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8887bf0f31e4b550bd988c8863b527b6587d200653e9375cd91eea2b944b7424", size = 172356, upload-time = "2026-03-16T15:20:10.245Z" },
-    { url = "https://files.pythonhosted.org/packages/ef/93/73a77b54ba94e82f76d02563c588d8a062513062675f483a033a43015f2c/hiredis-3.3.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:1ac7697365dbe45109273b34227fee6826b276ead9a4a007e0877e1d3f0fcf21", size = 166433, upload-time = "2026-03-16T15:20:11.789Z" },
-    { url = "https://files.pythonhosted.org/packages/f3/c2/1b2dcbe5dc53a46a8cb05bed67d190a7e30bad2ad1f727ebe154dfeededd/hiredis-3.3.1-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:2b6da6e07359107c653a809b3cff2d9ccaeedbafe33c6f16434aef6f53ce4a2b", size = 177220, upload-time = "2026-03-16T15:20:12.991Z" },
-    { url = "https://files.pythonhosted.org/packages/02/09/f4314cf096552568b5ea785ceb60c424771f4d35a76c410ad39d258f74bc/hiredis-3.3.1-cp314-cp314-musllinux_1_2_s390x.whl", hash = "sha256:ce334915f5d31048f76a42c607bf26687cf045eb1bc852b7340f09729c6a64fc", size = 170475, upload-time = "2026-03-16T15:20:14.519Z" },
-    { url = "https://files.pythonhosted.org/packages/b1/2e/3f56e438efc8fc27ed4a3dbad58c0280061466473ec35d8f86c90c841a84/hiredis-3.3.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:ee11fd431f83d8a5b29d370b9d79a814d3218d30113bdcd44657e9bdf715fc92", size = 167913, upload-time = "2026-03-16T15:20:15.672Z" },
-    { url = "https://files.pythonhosted.org/packages/56/34/053e5ee91d6dc478faac661996d1fd4886c5acb7a1b5ac30e7d3c794bb51/hiredis-3.3.1-cp314-cp314-win32.whl", hash = "sha256:e0356561b4a97c83b9ee3de657a41b8d1a1781226853adaf47b550bb988fda6f", size = 21167, upload-time = "2026-03-16T15:20:17.013Z" },
-    { url = "https://files.pythonhosted.org/packages/ea/33/06776c641d17881a9031e337e81b3b934c38c2adbb83c85062d6b5f83b72/hiredis-3.3.1-cp314-cp314-win_amd64.whl", hash = "sha256:80aba5f85d6227faee628ae28d1c3b69c661806a0636548ac56c68782606454f", size = 23000, upload-time = "2026-03-16T15:20:17.966Z" },
-    { url = "https://files.pythonhosted.org/packages/dd/5a/94f9a505b2ff5376d4a05fb279b69d89bafa7219dd33f6944026e3e56f80/hiredis-3.3.1-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:907f7b5501a534030738f0f27459a612d2266fd0507b007bb8f3e6de08167920", size = 83039, upload-time = "2026-03-16T15:20:19.316Z" },
-    { url = "https://files.pythonhosted.org/packages/93/ae/d3752a8f03a1fca43d402389d2a2d234d3db54c4d1f07f26c1041ca3c5de/hiredis-3.3.1-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:de94b409f49eb6a588ebdd5872e826caec417cd77c17af0fb94f2128427f1a2a", size = 46703, upload-time = "2026-03-16T15:20:20.401Z" },
-    { url = "https://files.pythonhosted.org/packages/9f/76/e32c868a2fa23cd82bacaffd38649d938173244a0e717ec1c0c76874dbdd/hiredis-3.3.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:79cd03e7ff550c17758a7520bf437c156d3d4c8bb74214deeafa69cda49c85a4", size = 42379, upload-time = "2026-03-16T15:20:21.705Z" },
-    { url = "https://files.pythonhosted.org/packages/c9/f6/d687d36a74ce6cf448826cf2e8edfc1eb37cc965308f74eb696aa97c69df/hiredis-3.3.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6ffa7ba2e2da1f806f3181b9730b3e87ba9dbfec884806725d4584055ba3faa6", size = 180311, upload-time = "2026-03-16T15:20:23.037Z" },
-    { url = "https://files.pythonhosted.org/packages/db/ac/f520dc0066a62a15aa920c7dd0a2028c213f4862d5f901409ae92ee5d785/hiredis-3.3.1-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:ee37fe8cf081b72dea72f96a0ee604f492ec02252eb77dc26ff6eec3f997b580", size = 190488, upload-time = "2026-03-16T15:20:24.357Z" },
-    { url = "https://files.pythonhosted.org/packages/4d/f5/ae10fff82d0f291e90c41bf10a5d6543a96aae00cccede01bf2b6f7e178d/hiredis-3.3.1-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:9bfdeff778d3f7ff449ca5922ab773899e7d31e26a576028b06a5e9cf0ed8c34", size = 189210, upload-time = "2026-03-16T15:20:25.51Z" },
-    { url = "https://files.pythonhosted.org/packages/0f/8f/5be4344e542aa8d349a03d05486c59d9ca26f69c749d11e114bf34b84d50/hiredis-3.3.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:027ce4fabfeff5af5b9869d5524770877f9061d118bc36b85703ae3faf5aad8e", size = 180971, upload-time = "2026-03-16T15:20:26.631Z" },
-    { url = "https://files.pythonhosted.org/packages/41/a2/29e230226ec2a31f13f8a832fbafe366e263f3b090553ebe49bb4581a7bd/hiredis-3.3.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:dcea8c3f53674ae68e44b12e853b844a1d315250ca6677b11ec0c06aff85e86c", size = 175314, upload-time = "2026-03-16T15:20:27.848Z" },
-    { url = "https://files.pythonhosted.org/packages/89/2e/bf241707ad86b9f3ebfbc7ab89e19d5ec243ff92ca77644a383622e8740b/hiredis-3.3.1-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:0b5ff2f643f4b452b0597b7fe6aa35d398cb31d8806801acfafb1558610ea2aa", size = 185652, upload-time = "2026-03-16T15:20:29.364Z" },
-    { url = "https://files.pythonhosted.org/packages/d0/c1/b39170d8bcccd01febd45af4ac6b43ff38e134a868e2ec167a82a036fb35/hiredis-3.3.1-cp314-cp314t-musllinux_1_2_s390x.whl", hash = "sha256:3586c8a5f56d34b9dddaaa9e76905f31933cac267251006adf86ec0eef7d0400", size = 179033, upload-time = "2026-03-16T15:20:30.549Z" },
-    { url = "https://files.pythonhosted.org/packages/b7/3a/4fe39a169115434f911abff08ff485b9b6201c168500e112b3f6a8110c0a/hiredis-3.3.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:a110d19881ca78a88583d3b07231e7c6864864f5f1f3491b638863ea45fa8708", size = 176126, upload-time = "2026-03-16T15:20:31.958Z" },
-    { url = "https://files.pythonhosted.org/packages/44/99/c1d0b0bc4f9e9150e24beb0dca2e186e32d5e749d0022e0d26453749ed51/hiredis-3.3.1-cp314-cp314t-win32.whl", hash = "sha256:98fd5b39410e9d69e10e90d0330e35650becaa5dd2548f509b9598f1f3c6124d", size = 22028, upload-time = "2026-03-16T15:20:33.33Z" },
-    { url = "https://files.pythonhosted.org/packages/35/d6/191e6741addc97bcf5e755661f8c82f0fd0aa35f07ece56e858da689b57e/hiredis-3.3.1-cp314-cp314t-win_amd64.whl", hash = "sha256:ab1f646ff531d70bfd25f01e60708dfa3d105eb458b7dedd9fe9a443039fd809", size = 23811, upload-time = "2026-03-16T15:20:34.292Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/e5/9e47dda8f1d55e77293c6cdf4169182b7f2f55b56913d1fb16a0ddf63a3d/hiredis-3.4.0-cp313-cp313-macosx_10_15_universal2.whl", hash = "sha256:4f0e3536eea76c03435d411099d165850bc3c9d873efe62843b995027135a763", size = 138688, upload-time = "2026-06-03T16:22:31.825Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/07/039bcf7ce8262ed66db736349c121486874826248ccd70c98c2f830ec9da/hiredis-3.4.0-cp313-cp313-macosx_10_15_x86_64.whl", hash = "sha256:82860f050aabd08c046f304eb57c105bb3d5a7370f79a4a0b74d2b771767cc13", size = 74666, upload-time = "2026-06-03T16:22:32.758Z" },
+    { url = "https://files.pythonhosted.org/packages/29/6d/692c50d846a0a36578e9ef0c62c6193ce01a48f353f6961de9de88a30b37/hiredis-3.4.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:74bcfb26189939daba2a0eb4bad05a6a30773bb2461f3d9967b8ced224bd0de9", size = 70119, upload-time = "2026-06-03T16:22:33.692Z" },
+    { url = "https://files.pythonhosted.org/packages/28/5d/c8b9ca711b4d6b7637eae744d6b45ea47f6bded61bac0232bb42ed8c583e/hiredis-3.4.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d95b602ab022f3505288ce51feaa48c072a62e57da55d6a7a38ecb8c5ad67d81", size = 306364, upload-time = "2026-06-03T16:22:34.62Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/7e/e940eea3c2ee1aa5947f2e6224f03a1dfd38a5813307259a25f580411820/hiredis-3.4.0-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:de3e2297a182253dfa4400883a9a4fb46d44946aed3157ea2da873b93e2525c4", size = 339454, upload-time = "2026-06-03T16:22:35.87Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/ea/b8147da5c270a2a5b85090c97d0ff7e2fae6e7c5f7749f8c3c2decadd3ac/hiredis-3.4.0-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:454236d2a5bd917daf38914ce363e71aeef41240e6800f4799e04ee82689bfd2", size = 351457, upload-time = "2026-06-03T16:22:36.95Z" },
+    { url = "https://files.pythonhosted.org/packages/33/b5/ff8fe4f812348f09d2943b109cb64c5301af4f601e1cf026518e93a72fff/hiredis-3.4.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:35ab3653569b9867b8d8a3b4c0684a20dc769fe45d4666bedfe9a3391a61b30b", size = 312970, upload-time = "2026-06-03T16:22:38.004Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/2a/c90dff527cb2521ee1687e9e30bdf1156f2f4acfd47833b44dc52fec3ec6/hiredis-3.4.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:afff0876dafad6d3bb446c907da2836954876243f6bb9d5e44915d175e424aa4", size = 300850, upload-time = "2026-06-03T16:22:39.146Z" },
+    { url = "https://files.pythonhosted.org/packages/90/0b/c48e93a1e524198b10ccc26d770368547c0c29d126a992fd4b4aa533f1ac/hiredis-3.4.0-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:d5c33eb2da5c9ccd281c396e1c618cfe6a91eb841e957f17d2fa520383b3111d", size = 331430, upload-time = "2026-06-03T16:22:40.248Z" },
+    { url = "https://files.pythonhosted.org/packages/95/12/ed5bdc482d5c98930ffa264dd707dfb04b83118b2f7f760760c5dfbe6782/hiredis-3.4.0-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:04e54fc3bcecf8c7cb2846947b84baf7ce1507caba641bd23590c52fefade865", size = 333021, upload-time = "2026-06-03T16:22:41.363Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/42/d4a2e7be82f2b2db7b67ec622806ba099d8fe09d218568f71197922cbe79/hiredis-3.4.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:5f1ddfe6429f9adc0a8d705afbcd40530fddeafa919873ffbb11f59eda44dbb9", size = 311747, upload-time = "2026-06-03T16:22:42.374Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/33/b5ac3420bd803ca9affd68a4a2a6111812bd26bfb9d6b41a721e009d79d9/hiredis-3.4.0-cp313-cp313-win32.whl", hash = "sha256:165e6405b48f9bd66ddb4ad52ce28b0c0041a0308654d7a0cb4357a1939134dc", size = 38921, upload-time = "2026-06-03T16:22:43.513Z" },
+    { url = "https://files.pythonhosted.org/packages/03/e7/76e68122b1cf680b93b951a82953fff5b5883dc08ec93f63677eb3653591/hiredis-3.4.0-cp313-cp313-win_amd64.whl", hash = "sha256:306aae11a52e495aaf0a14e3efcd7b51029e632c74b847bc03159e1e1f6db591", size = 40095, upload-time = "2026-06-03T16:22:44.296Z" },
+    { url = "https://files.pythonhosted.org/packages/20/05/9313dc27ed159512dc22b4ecf8a62a84d0aa5fbd500ffdad955b361cb2a8/hiredis-3.4.0-cp313-cp313-win_arm64.whl", hash = "sha256:975a8e75a10425442037dd9c7abbaae31941c34328d9f01b1ca42d9db44ac31d", size = 36884, upload-time = "2026-06-03T16:22:45.134Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/ea/cbc922aeaa5af11f1c1235d8b2b04ff8cdf6e3e95c785a500521f32d8d70/hiredis-3.4.0-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:d3a12ae5685e9621a988af07b5af0ad685c7d19d6a7246ac852e35060178cff4", size = 138762, upload-time = "2026-06-03T16:22:45.927Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/e9/e004067ffad9f707174cde04d117c985d5f22dd4d9409f0983892738cb44/hiredis-3.4.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:0a70df45cf167b5af99b9fe3e2044716919e30580a869dfa766f2a6467c0c320", size = 74696, upload-time = "2026-06-03T16:22:46.924Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/d1/5fe5b6d05e59116d78f9d228d9cc0022efbb84d234333c5fbe6a0c6e13fe/hiredis-3.4.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:0a68b0e48509e6e66f4c212e53d98f29178addf83b0701a71bf0fce792954419", size = 70163, upload-time = "2026-06-03T16:22:47.798Z" },
+    { url = "https://files.pythonhosted.org/packages/db/93/c86f0a7ae2cd10b72e30476f87aafd1af22992e080feb4b5d2ec1cbdf4e4/hiredis-3.4.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a45822bc8487da8151fe67c788de74b834582b1d510c67b888fcda64bf6ba4bb", size = 306631, upload-time = "2026-06-03T16:22:48.671Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/10/3746b028d9c43fab1fa4126fe69c6967df89ab9819140092930322b0550c/hiredis-3.4.0-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:0b82cab9ad7a1574ab273a78942f780c1b1496101eb342b630c46c3e918ca21b", size = 339758, upload-time = "2026-06-03T16:22:49.662Z" },
+    { url = "https://files.pythonhosted.org/packages/59/f3/c6fb383854237891039a4d94d3e66dc5eec8a2993fed6020c983d63c5393/hiredis-3.4.0-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:db13f8039ad8229f77f0e242be14e53bd67e8f3aadeb16f3af30944287cca092", size = 351360, upload-time = "2026-06-03T16:22:50.779Z" },
+    { url = "https://files.pythonhosted.org/packages/70/b7/32110aa458690722a1069c7349b8ebe374a6ba0bdf9ef8925a9f37a74978/hiredis-3.4.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:54b6267918c66d8ba4a3cf519db1235a4bd56d2a0969ca5b2ae3c6b6b7d9ed79", size = 313070, upload-time = "2026-06-03T16:22:51.966Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/23/bccfa0fb7b1b529cff35c8725cfd99a2d18fa4123f52f52bf03e84210855/hiredis-3.4.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:88396e6a24b80c86f4dc180964d9cc467ba3aa3c886af6532fe077c5a5dc0c3c", size = 300927, upload-time = "2026-06-03T16:22:53.085Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/0f/e1e2295ee863efc7ce8c88ec10bcc4b1504352373998cb493f10e900dbe5/hiredis-3.4.0-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:73dd607b47863633d8070f1eb3bab1b3b097ee747783fe69c0dd0f93ec673d8b", size = 331764, upload-time = "2026-06-03T16:22:54.194Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/df/11b1de2ac85dfd7a8713d72a6ed7ac0f1a6e28d906bd362e0df3a27f5c86/hiredis-3.4.0-cp314-cp314-musllinux_1_2_s390x.whl", hash = "sha256:e6e8d5fa63ec2a0738d188488e828818cbe4cb4d37c0c706836cf3888d82c53d", size = 333144, upload-time = "2026-06-03T16:22:55.277Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/10/4b104565c936d51b4b02597352ec068937c9d6a73a3c4c9609c08ae3923e/hiredis-3.4.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:d77901d058923a09ed25063ea6fb2842c153bbe75060a46e3949e73ad12ce352", size = 311593, upload-time = "2026-06-03T16:22:56.573Z" },
+    { url = "https://files.pythonhosted.org/packages/70/ae/c9eda3c116bef50fcf0dc7e44379e3577f3627caca4ffd7af04675b02d98/hiredis-3.4.0-cp314-cp314-win32.whl", hash = "sha256:05384fcfe5851b5af868bf24265c14ab86f38562679f9c6f712895b67a98163c", size = 39662, upload-time = "2026-06-03T16:22:57.683Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/c8/cedb336a0386a97271761ace460a362cb2433c6cdf1d1ba760ad99225734/hiredis-3.4.0-cp314-cp314-win_amd64.whl", hash = "sha256:53233656e4fecf9f8ec654f1f4c5d445bf1c2957d7f63ffdedbba2682c9d1584", size = 40682, upload-time = "2026-06-03T16:22:58.526Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/ea/3a05247ce4e2afe56f59d24b73ba38e37f2b324dba8290beba56fbd9fd1f/hiredis-3.4.0-cp314-cp314-win_arm64.whl", hash = "sha256:3348ba4e101f3a96c927447ff2edcb3e0026dc6df375ba117485a43edcbb6980", size = 37541, upload-time = "2026-06-03T16:22:59.307Z" },
+    { url = "https://files.pythonhosted.org/packages/35/14/caeaa1be1205ebdc1cf6760c5f6882afbdb3b82a6bdf0559d01205b1c857/hiredis-3.4.0-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:3159c54fe560aa30bf1ab76e65c4c23dc45ad79d7cf4aecc25ec9942f5ea4cea", size = 139787, upload-time = "2026-06-03T16:23:00.139Z" },
+    { url = "https://files.pythonhosted.org/packages/49/85/8f52b485b9d835e0f8da063a635290d916a6f5ab60c18db5411ecea344d1/hiredis-3.4.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:be4a41496a0a48c3abf57ef1bbeb11980060ce9c7a1dd8b92caa028a813a9c59", size = 75136, upload-time = "2026-06-03T16:23:01.705Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/09/ee568562f36f481395d5cea3ab75fd9350cd77d98d55ee5f9b395f3fc358/hiredis-3.4.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:a2f9a9a591b3eaade523f3e778dfcd8684965ee6e954ae25cd2fd6d8c75e881d", size = 70772, upload-time = "2026-06-03T16:23:02.765Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/0d/3cb03fbbe72f86541f42ee49dba95ff428c87908815152970fbf24bdcf4c/hiredis-3.4.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6c2852eaa26c0a73be4a30118cd5ad6a77c095d224ccb5ac38e40cb865747d22", size = 315571, upload-time = "2026-06-03T16:23:03.826Z" },
+    { url = "https://files.pythonhosted.org/packages/52/fc/c8667282e41153bc20930aeba8ba0dff989cbaa9eb7594f8bcac02558dea/hiredis-3.4.0-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:18ff3d9b23ebe6c8248c3debca2402ad209d60c48495e7ed76407c2fe54cb9b4", size = 348131, upload-time = "2026-06-03T16:23:05.077Z" },
+    { url = "https://files.pythonhosted.org/packages/99/13/5431ace8330904b2b9d9ce5425c13b7a8fa2b443ff272a92f248c07e6400/hiredis-3.4.0-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:94f83352295bf3d332678689ecd4ce190a4d233a20ad2f432724efd3ce03e49a", size = 359915, upload-time = "2026-06-03T16:23:06.293Z" },
+    { url = "https://files.pythonhosted.org/packages/be/57/30dab05cf2a70905e5d2807edd4afa30a4747599070faf80f18e61375e11/hiredis-3.4.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:393d5e7c8c67cdddf7109a8e925d885e788f3f43e5b1043f84390df40c59944b", size = 321426, upload-time = "2026-06-03T16:23:07.447Z" },
+    { url = "https://files.pythonhosted.org/packages/33/6f/0a6e030d96d927000735b39aa8b8fef03b43fafdf4a79c80755be351a0f5/hiredis-3.4.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:7e7ab4c1c8c4d365b02d9e82cdf25b01a065edf2ededd7b5acb043201ff80203", size = 309862, upload-time = "2026-06-03T16:23:08.672Z" },
+    { url = "https://files.pythonhosted.org/packages/11/48/26b2771d2b2403124c1f97c2a6d45df0ba3fa59f0c2d4d244e90543722fb/hiredis-3.4.0-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:cfe23f8dcf2c0f4e03d107ff68a9ee9707f9d76abeddbe59633e5de1564a650c", size = 339568, upload-time = "2026-06-03T16:23:09.755Z" },
+    { url = "https://files.pythonhosted.org/packages/07/b1/01c18f676d5dea65e894c01ffae8da2f15df1fceed1c69b16877ba57be60/hiredis-3.4.0-cp314-cp314t-musllinux_1_2_s390x.whl", hash = "sha256:a7e76904148c229549db7240a4f9963deb8bb328c0c0844fc9f2320aca05b530", size = 341424, upload-time = "2026-06-03T16:23:10.964Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/58/ab3a5672e506f282e1dd6dfb1c0c3f7e17f02398280c2a2994f8d7b478ba/hiredis-3.4.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:92b570225f6097430615a82543c3eb7974ca354738a6cef38053138f7d983151", size = 320386, upload-time = "2026-06-03T16:23:12.174Z" },
+    { url = "https://files.pythonhosted.org/packages/15/af/3f26324cca720f56ace408883c1c7311ce71b571e82e6434515f7ba4eb59/hiredis-3.4.0-cp314-cp314t-win32.whl", hash = "sha256:decc176d86127c620b5d280b3fe5f97a788be58ca945971f3852c3bf54f4d5ad", size = 40516, upload-time = "2026-06-03T16:23:13.179Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/18/e011a424a9608ff152ebeb7bbae2be3163e5716e92cf75baddcb5a8fc312/hiredis-3.4.0-cp314-cp314t-win_amd64.whl", hash = "sha256:05c852c58fec65d4c9fb861372dd7391d8b2ce96c960ba8714145f8cd85cd0ec", size = 41453, upload-time = "2026-06-03T16:23:14.091Z" },
+    { url = "https://files.pythonhosted.org/packages/43/5f/829287555ce7286be8d6c87c69f93aa1f38fe67c46740806416142231cf3/hiredis-3.4.0-cp314-cp314t-win_arm64.whl", hash = "sha256:7ff29c9f5d3c91fda948c2fde58f457b3244550781d3bc0891b1b9d93c10f47f", size = 37968, upload-time = "2026-06-03T16:23:14.948Z" },
 ]
 
 [[package]]
@@ -1662,18 +1678,19 @@ http2 = [
 
 [[package]]
 name = "huey"
-version = "2.6.0"
+version = "3.0.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/fe/29/3428d52eb8e85025e264a291641a9f9d6407cc1e51d1b630f6ac5815999a/huey-2.6.0.tar.gz", hash = "sha256:8d11f8688999d65266af1425b831f6e3773e99415027177b8734b0ffd5e251f6", size = 221068, upload-time = "2026-01-06T03:01:02.055Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e1/01/5f0fb711585af22412baee31a9a6a88975c33a58c57ec618e09be20bcc88/huey-3.0.1.tar.gz", hash = "sha256:83ca54fa77c4ee27349393212fc13088142244f491be903f620a9e46e8fca4ce", size = 253328, upload-time = "2026-05-14T15:35:02.809Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/1a/34/fae9ac8f1c3a552fd3f7ff652b94c78d219dedc5fce0c0a4232457760a00/huey-2.6.0-py3-none-any.whl", hash = "sha256:1b9df9d370b49c6d5721ba8a01ac9a787cf86b3bdc584e4679de27b920395c3f", size = 76951, upload-time = "2026-01-06T03:01:00.808Z" },
+    { url = "https://files.pythonhosted.org/packages/20/37/1056e57ffb9d0fa1b859e02c9e5f7cf1e8276c8f5b610050e2a755f5c060/huey-3.0.1-py3-none-any.whl", hash = "sha256:5de8ff852021da670efe8d4d78db8719c0255ebbde0772766a0114f997ea61f6", size = 86331, upload-time = "2026-05-14T15:35:01.314Z" },
 ]
 
 [[package]]
 name = "huggingface-hub"
-version = "1.16.1"
+version = "1.17.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
+    { name = "click" },
     { name = "filelock" },
     { name = "fsspec" },
     { name = "hf-xet", marker = "platform_machine == 'AMD64' or platform_machine == 'aarch64' or platform_machine == 'amd64' or platform_machine == 'arm64' or platform_machine == 'x86_64'" },
@@ -1684,9 +1701,9 @@ dependencies = [
     { name = "typer" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/48/0f/ed994dbade67a54407c28cab96ef845e0e6d25500be56aca6394f8bfc9dd/huggingface_hub-1.16.1.tar.gz", hash = "sha256:7f1dc4c5ec21aed69be630ad0c3378616be16f3de1a47b141c0e812965d9c832", size = 792534, upload-time = "2026-05-21T18:40:00.908Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/bd/65/9826515abb600b5722bcf53f8b4a2fb58340b1f8bfcaee19f83561c13a44/huggingface_hub-1.17.0.tar.gz", hash = "sha256:fad842b6763ef70ebc3919665b1b9273645203185400a7d6c5eddc2323cc3435", size = 797082, upload-time = "2026-05-28T15:12:13.347Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/49/79/621a7dbb80c70974f73a597275351ebe03ce5bc65cb5f8f4acb5859252bc/huggingface_hub-1.16.1-py3-none-any.whl", hash = "sha256:64340de934b9ce37857ef85a82de72f5629e8a270f9119eabb12bf495eb53c22", size = 668176, upload-time = "2026-05-21T18:39:58.596Z" },
+    { url = "https://files.pythonhosted.org/packages/02/28/d7cef5e477b855c25d415b8f57e5bc7347c7a90cad3acf1725d0c92ca294/huggingface_hub-1.17.0-py3-none-any.whl", hash = "sha256:3b8156d23118e87f6a587648bfbc04f04a12a757ccb4ed298b35c4ae638bf24c", size = 671546, upload-time = "2026-05-28T15:12:11.441Z" },
 ]
 
 [[package]]
@@ -1709,11 +1726,11 @@ wheels = [
 
 [[package]]
 name = "idna"
-version = "3.16"
+version = "3.18"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/1a/88/bcf9709822fe69d02c2a6a77956c98ce6ea8ca8767a9aadcedc7eb6a2390/idna-3.16.tar.gz", hash = "sha256:d7a6da03db833450fca25d2358ac9ff06cd624577a4aea3a596d5c0f77b8e03d", size = 203770, upload-time = "2026-05-22T00:16:18.781Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/cd/63/9496c57188a2ee585e0f1db071d75089a11e98aa86eb99d9d7618fc1edce/idna-3.18.tar.gz", hash = "sha256:ffb385a7e039654cef1ab9ef32c6fafe283c0c0467bba1d9029738ce4a14a848", size = 196711, upload-time = "2026-06-02T14:34:07.794Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/94/16/70255075a9859a0e3adb789b68ceb0e210dec03934245fd98d248226572f/idna-3.16-py3-none-any.whl", hash = "sha256:cc246e3a3f89580c3a951b5ad298ca4638078b2cdd4f115654332b5c26daded5", size = 74165, upload-time = "2026-05-22T00:16:16.698Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/5e/d4e9f1a599fb8e573b7b87160658329fbf28d19eac2718f51fc3def3aa5a/idna-3.18-py3-none-any.whl", hash = "sha256:7f952cbe720b688055e3f87de14f5c3e5fdaa8bc3928985c4077ca689de849a2", size = 65455, upload-time = "2026-06-02T14:34:06.319Z" },
 ]
 
 [[package]]
@@ -1763,7 +1780,7 @@ wheels = [
 
 [[package]]
 name = "ipython"
-version = "9.13.0"
+version = "9.14.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
@@ -1773,14 +1790,14 @@ dependencies = [
     { name = "matplotlib-inline" },
     { name = "pexpect", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
     { name = "prompt-toolkit" },
-    { name = "psutil" },
+    { name = "psutil", marker = "sys_platform != 'emscripten'" },
     { name = "pygments" },
     { name = "stack-data" },
     { name = "traitlets" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/cd/c4/87cda5842cf5c31837c06ddb588e11c3c35d8ece89b7a0108c06b8c9b00a/ipython-9.13.0.tar.gz", hash = "sha256:7e834b6afc99f020e3f05966ced34792f40267d64cb1ea9043886dab0dde5967", size = 4430549, upload-time = "2026-04-24T12:24:55.221Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/21/c2/c0064cf15d026501a1ef70e42efd9c3f818663089399aacc5e37a82901c1/ipython-9.14.0.tar.gz", hash = "sha256:6f27ff0f1d9ea050e0551f71568bc4b34d8aba579e8f111c5b4175f44ac6b4aa", size = 4432601, upload-time = "2026-05-29T15:13:24.611Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b9/86/3060e8029b7cc505cce9a0137431dda81d0a3fde93a8f0f50ee0bf37a795/ipython-9.13.0-py3-none-any.whl", hash = "sha256:57f9d4639e20818d328d287c7b549af3d05f12486ea8f2e7f73e52a36ec4d201", size = 627274, upload-time = "2026-04-24T12:24:53.038Z" },
+    { url = "https://files.pythonhosted.org/packages/14/a3/9e59340f02c1dc8f8c0a05b09244712b8609eb5439f9996e887e2b82f452/ipython-9.14.0-py3-none-any.whl", hash = "sha256:8fd984a3372c14b12790b084ba6b5cff5678c0cb063244a0034f06a51f20d6c2", size = 627457, upload-time = "2026-05-29T15:13:22.942Z" },
 ]
 
 [[package]]
@@ -2284,7 +2301,7 @@ wheels = [
 
 [[package]]
 name = "mlflow"
-version = "3.12.0"
+version = "3.13.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiohttp" },
@@ -2308,14 +2325,14 @@ dependencies = [
     { name = "sqlalchemy" },
     { name = "waitress", marker = "sys_platform == 'win32'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/3b/e3/b2148a6d6f38731d3dda49a7e46cf6932a458aa0aa5414b80e6e7251fa1d/mlflow-3.12.0.tar.gz", hash = "sha256:227ee31c6abf7ae3b3c38d4ca87c356e107578740c1efee89da43f2a5b9e3b47", size = 9939137, upload-time = "2026-05-05T10:28:58.312Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/8e/69/d71afc475fa7e7b22bb27392247d2a3015c9da202dea44f150a54be4bd67/mlflow-3.13.0.tar.gz", hash = "sha256:a95198d592a8a15fad3db7f56b228acc9422c09f0daa7c6c976a9996ab73c3e2", size = 10086808, upload-time = "2026-06-01T05:55:09.555Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7e/f8/47f28975c1c1b70d351fa19c5aef21cef5ae1e1aca36bd1858798384bdbb/mlflow-3.12.0-py3-none-any.whl", hash = "sha256:e1c28ed4c48557cc52c766f17f1ca5826753ddf241d43f30f99c45f7ea6b3ce0", size = 10625639, upload-time = "2026-05-05T10:28:55.777Z" },
+    { url = "https://files.pythonhosted.org/packages/07/1f/d44140128356f2f5db37f9fb4d9da31123d839d49f3fe00a079cd35bfe20/mlflow-3.13.0-py3-none-any.whl", hash = "sha256:7ca9cb2f623f300dabadaf5e985c85af77c5db3d7c36f56769d22c101b132f6c", size = 10788121, upload-time = "2026-06-01T05:55:06.86Z" },
 ]
 
 [[package]]
 name = "mlflow-skinny"
-version = "3.12.0"
+version = "3.13.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "cachetools" },
@@ -2339,14 +2356,14 @@ dependencies = [
     { name = "typing-extensions" },
     { name = "uvicorn" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/0f/c0/9cbe24b4abcbadb3a3cdab65bfd552b6b75de64374b477abac89190d25d0/mlflow_skinny-3.12.0.tar.gz", hash = "sha256:74d27066bc9553d281e0c31d25f07deb39dbe99d190e4f7c257703e5c8ee6d10", size = 2723866, upload-time = "2026-05-05T10:28:46.388Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/13/840db21a4f46ebe6ba9837a38bc93d748e23b6b61986799c8040cd4bf728/mlflow_skinny-3.13.0.tar.gz", hash = "sha256:d2273bfa21f776359f7d6ab2267967e3a6732a5fb00996ad433d0e777dfa3b71", size = 2814837, upload-time = "2026-06-01T05:54:54.175Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/95/05/2df60fab37881c490e9364ea697a6c3a78d3b593fde2d9332a75f8cdf1f8/mlflow_skinny-3.12.0-py3-none-any.whl", hash = "sha256:0498f3697abcabcc6204c432ef179840f6a7a34ce123837c98c1913064fda6dd", size = 3261903, upload-time = "2026-05-05T10:28:44.24Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/fd/f2739de1b6a09da981927aa90db87340cbe4b3cf6cd175fd5e6e4366208e/mlflow_skinny-3.13.0-py3-none-any.whl", hash = "sha256:ced3d9a580564fae093d14732df8531fb180574f6483d4c642b6083879eb86fc", size = 3365675, upload-time = "2026-06-01T05:54:52.166Z" },
 ]
 
 [[package]]
 name = "mlflow-tracing"
-version = "3.12.0"
+version = "3.13.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "cachetools" },
@@ -2358,9 +2375,9 @@ dependencies = [
     { name = "protobuf" },
     { name = "pydantic" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/a5/13/d32fe4cca53dde68f09fd38c545ea709e8565fd7c2ffd7c5eff99e504aaf/mlflow_tracing-3.12.0.tar.gz", hash = "sha256:8702a34a1d4f1517ba904d716f5a8fca4675e6526f7d164d02bdaabececa2d80", size = 1352412, upload-time = "2026-05-05T10:28:51.115Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ec/b0/5912313e895e6ce02f1f67110164d147593d1b5379a4767a30a5b9e730c5/mlflow_tracing-3.13.0.tar.gz", hash = "sha256:42c435b0fdcab00f1865cab4a52f7a85a2a08d68a959f36bcf90a1c9fe65db0a", size = 1393079, upload-time = "2026-06-01T05:54:44.906Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a5/bf/e22b778addbe19a7a912400c37a197ee9cdebc1641e3b0a3882c30da6ee4/mlflow_tracing-3.12.0-py3-none-any.whl", hash = "sha256:c6072553f47b42505dc7ee62946688a4a0dde8f06b78fbc60e946397b20e1518", size = 1618720, upload-time = "2026-05-05T10:28:48.999Z" },
+    { url = "https://files.pythonhosted.org/packages/94/fd/2c53ebc2f7fbb34ed4a3913a71ff53962e6be35fa02f7cee1f52c77388cd/mlflow_tracing-3.13.0-py3-none-any.whl", hash = "sha256:2f8187ce2b1af7419be71d2d8ab5fec53d207d4b8d703cd15e5db64939098d72", size = 1664279, upload-time = "2026-06-01T05:54:42.911Z" },
 ]
 
 [[package]]
@@ -2532,6 +2549,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/a2/6e/371856a3fb9d31ca8dac321cda606860fa4548858c0cc45d9d1d4ca2628b/mypy_extensions-1.1.0.tar.gz", hash = "sha256:52e68efc3284861e772bbcd66823fde5ae21fd2fdb51c62a211403730b916558", size = 6343, upload-time = "2025-04-22T14:54:24.164Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/79/7b/2c79738432f5c924bef5071f933bcc9efd0473bac3b4aa584a6f7c1c8df8/mypy_extensions-1.1.0-py3-none-any.whl", hash = "sha256:1be4cccdb0f2482337c4743e60421de3a356cd97508abadd57d47403e94f5505", size = 4963, upload-time = "2025-04-22T14:54:22.983Z" },
+]
+
+[[package]]
+name = "narwhals"
+version = "2.22.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/9c/1c/c80cb7719721a44846c6301ef118434bae30a423924bfad3a47f16bdc064/narwhals-2.22.0.tar.gz", hash = "sha256:6486282bb7e4b4ab55963efbd8be1451b764cc4874b74d1fd625eba9dc60b86f", size = 417565, upload-time = "2026-06-01T13:34:36.249Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1f/b6/e7cdde7b8e90d5dff25b622f95833ef26567ad184c977278b93a1cbd5717/narwhals-2.22.0-py3-none-any.whl", hash = "sha256:1421797ede01789cc1537619dbc3f36f840737240f748fdb24a60a0225fc80be", size = 453815, upload-time = "2026-06-01T13:34:34.127Z" },
 ]
 
 [[package]]
@@ -3002,11 +3028,11 @@ wheels = [
 
 [[package]]
 name = "pip"
-version = "26.1.1"
+version = "26.1.2"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/b6/48/cb9b7a682f6fe01a4221e1728941dd4ac3cd9090a17db3779d6ff490b602/pip-26.1.1.tar.gz", hash = "sha256:d36762751d156a4ee895de8af39aa0abeeeb577f93a2eca6ab62467bbf0f8a78", size = 1840400, upload-time = "2026-05-04T19:02:21.248Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/01/91/47e7d486260f618783899587af63ccf7980fb60245c3e63dd4571c6b57ad/pip-26.1.2.tar.gz", hash = "sha256:f49cd134c61cf2fd75e0ce2676db03e4054504a5a4986d00f8299ae632dc4605", size = 1840799, upload-time = "2026-05-31T17:33:58.56Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/3a/eb/fea4d1d51c49832120f7f285d07306db3960f423a2612c6057caf3e8196f/pip-26.1.1-py3-none-any.whl", hash = "sha256:99cb1c2899893b075ff56e4ed0af55669a955b49ad7fb8d8603ecdaf4ed653fb", size = 1812777, upload-time = "2026-05-04T19:02:18.9Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/95/6b5cb3461ea5673ba0995989746db58eb18b91b54dbf331e72f569540946/pip-26.1.2-py3-none-any.whl", hash = "sha256:382ff9f685ee3bc25864f820aa50505825f10f5458ffff07e30a6d96e5715cab", size = 1813144, upload-time = "2026-05-31T17:33:56.772Z" },
 ]
 
 [[package]]
@@ -3057,11 +3083,11 @@ wheels = [
 
 [[package]]
 name = "platformdirs"
-version = "4.9.6"
+version = "4.10.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/9f/4a/0883b8e3802965322523f0b200ecf33d31f10991d0401162f4b23c698b42/platformdirs-4.9.6.tar.gz", hash = "sha256:3bfa75b0ad0db84096ae777218481852c0ebc6c727b3168c1b9e0118e458cf0a", size = 29400, upload-time = "2026-04-09T00:04:10.812Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d7/47/e4501f49c178ae1d9f4a75073fda4204f52647993f075a9db4d14930e0c5/platformdirs-4.10.0.tar.gz", hash = "sha256:31e761a6a0ca04faf7353ea759bdba55652be214725111e5aac52dfa29d4bef7", size = 31224, upload-time = "2026-05-28T03:32:53.587Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/75/a6/a0a304dc33b49145b21f4808d763822111e67d1c3a32b524a1baf947b6e1/platformdirs-4.9.6-py3-none-any.whl", hash = "sha256:e61adb1d5e5cb3441b4b7710bea7e4c12250ca49439228cc1021c00dcfac0917", size = 21348, upload-time = "2026-04-09T00:04:09.463Z" },
+    { url = "https://files.pythonhosted.org/packages/81/e6/cd9575ac904136b3cbf7aa7ee819ef86eedb7274e46f230e94ea4342e729/platformdirs-4.10.0-py3-none-any.whl", hash = "sha256:fb516cdb12eb0d857d0cd85a7c57cea4d060bee4578d6cf5a14dfdf8cbf8784a", size = 22743, upload-time = "2026-05-28T03:32:52.175Z" },
 ]
 
 [[package]]
@@ -3320,38 +3346,38 @@ wheels = [
 
 [[package]]
 name = "pyarrow"
-version = "23.0.1"
+version = "24.0.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/88/22/134986a4cc224d593c1afde5494d18ff629393d74cc2eddb176669f234a4/pyarrow-23.0.1.tar.gz", hash = "sha256:b8c5873e33440b2bc2f4a79d2b47017a89c5a24116c055625e6f2ee50523f019", size = 1167336, upload-time = "2026-02-16T10:14:12.39Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/91/13/13e1069b351bdc3881266e11147ffccf687505dbb0ea74036237f5d454a5/pyarrow-24.0.0.tar.gz", hash = "sha256:85fe721a14dd823aca09127acbb06c3ca723efbd436c004f16bca601b04dcc83", size = 1180261, upload-time = "2026-04-21T10:51:25.837Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/47/10/2cbe4c6f0fb83d2de37249567373d64327a5e4d8db72f486db42875b08f6/pyarrow-23.0.1-cp313-cp313-macosx_12_0_arm64.whl", hash = "sha256:6b8fda694640b00e8af3c824f99f789e836720aa8c9379fb435d4c4953a756b8", size = 34210066, upload-time = "2026-02-16T10:10:45.487Z" },
-    { url = "https://files.pythonhosted.org/packages/cb/4f/679fa7e84dadbaca7a65f7cdba8d6c83febbd93ca12fa4adf40ba3b6362b/pyarrow-23.0.1-cp313-cp313-macosx_12_0_x86_64.whl", hash = "sha256:8ff51b1addc469b9444b7c6f3548e19dc931b172ab234e995a60aea9f6e6025f", size = 35825526, upload-time = "2026-02-16T10:10:52.266Z" },
-    { url = "https://files.pythonhosted.org/packages/f9/63/d2747d930882c9d661e9398eefc54f15696547b8983aaaf11d4a2e8b5426/pyarrow-23.0.1-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:71c5be5cbf1e1cb6169d2a0980850bccb558ddc9b747b6206435313c47c37677", size = 44473279, upload-time = "2026-02-16T10:11:01.557Z" },
-    { url = "https://files.pythonhosted.org/packages/b3/93/10a48b5e238de6d562a411af6467e71e7aedbc9b87f8d3a35f1560ae30fb/pyarrow-23.0.1-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:9b6f4f17b43bc39d56fec96e53fe89d94bac3eb134137964371b45352d40d0c2", size = 47585798, upload-time = "2026-02-16T10:11:09.401Z" },
-    { url = "https://files.pythonhosted.org/packages/5c/20/476943001c54ef078dbf9542280e22741219a184a0632862bca4feccd666/pyarrow-23.0.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:9fc13fc6c403d1337acab46a2c4346ca6c9dec5780c3c697cf8abfd5e19b6b37", size = 48179446, upload-time = "2026-02-16T10:11:17.781Z" },
-    { url = "https://files.pythonhosted.org/packages/4b/b6/5dd0c47b335fcd8edba9bfab78ad961bd0fd55ebe53468cc393f45e0be60/pyarrow-23.0.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:5c16ed4f53247fa3ffb12a14d236de4213a4415d127fe9cebed33d51671113e2", size = 50623972, upload-time = "2026-02-16T10:11:26.185Z" },
-    { url = "https://files.pythonhosted.org/packages/d5/09/a532297c9591a727d67760e2e756b83905dd89adb365a7f6e9c72578bcc1/pyarrow-23.0.1-cp313-cp313-win_amd64.whl", hash = "sha256:cecfb12ef629cf6be0b1887f9f86463b0dd3dc3195ae6224e74006be4736035a", size = 27540749, upload-time = "2026-02-16T10:12:23.297Z" },
-    { url = "https://files.pythonhosted.org/packages/a5/8e/38749c4b1303e6ae76b3c80618f84861ae0c55dd3c2273842ea6f8258233/pyarrow-23.0.1-cp313-cp313t-macosx_12_0_arm64.whl", hash = "sha256:29f7f7419a0e30264ea261fdc0e5fe63ce5a6095003db2945d7cd78df391a7e1", size = 34471544, upload-time = "2026-02-16T10:11:32.535Z" },
-    { url = "https://files.pythonhosted.org/packages/a3/73/f237b2bc8c669212f842bcfd842b04fc8d936bfc9d471630569132dc920d/pyarrow-23.0.1-cp313-cp313t-macosx_12_0_x86_64.whl", hash = "sha256:33d648dc25b51fd8055c19e4261e813dfc4d2427f068bcecc8b53d01b81b0500", size = 35949911, upload-time = "2026-02-16T10:11:39.813Z" },
-    { url = "https://files.pythonhosted.org/packages/0c/86/b912195eee0903b5611bf596833def7d146ab2d301afeb4b722c57ffc966/pyarrow-23.0.1-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:cd395abf8f91c673dd3589cadc8cc1ee4e8674fa61b2e923c8dd215d9c7d1f41", size = 44520337, upload-time = "2026-02-16T10:11:47.764Z" },
-    { url = "https://files.pythonhosted.org/packages/69/c2/f2a717fb824f62d0be952ea724b4f6f9372a17eed6f704b5c9526f12f2f1/pyarrow-23.0.1-cp313-cp313t-manylinux_2_28_x86_64.whl", hash = "sha256:00be9576d970c31defb5c32eb72ef585bf600ef6d0a82d5eccaae96639cf9d07", size = 47548944, upload-time = "2026-02-16T10:11:56.607Z" },
-    { url = "https://files.pythonhosted.org/packages/84/a7/90007d476b9f0dc308e3bc57b832d004f848fd6c0da601375d20d92d1519/pyarrow-23.0.1-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:c2139549494445609f35a5cda4eb94e2c9e4d704ce60a095b342f82460c73a83", size = 48236269, upload-time = "2026-02-16T10:12:04.47Z" },
-    { url = "https://files.pythonhosted.org/packages/b0/3f/b16fab3e77709856eb6ac328ce35f57a6d4a18462c7ca5186ef31b45e0e0/pyarrow-23.0.1-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:7044b442f184d84e2351e5084600f0d7343d6117aabcbc1ac78eb1ae11eb4125", size = 50604794, upload-time = "2026-02-16T10:12:11.797Z" },
-    { url = "https://files.pythonhosted.org/packages/e9/a1/22df0620a9fac31d68397a75465c344e83c3dfe521f7612aea33e27ab6c0/pyarrow-23.0.1-cp313-cp313t-win_amd64.whl", hash = "sha256:a35581e856a2fafa12f3f54fce4331862b1cfb0bef5758347a858a4aa9d6bae8", size = 27660642, upload-time = "2026-02-16T10:12:17.746Z" },
-    { url = "https://files.pythonhosted.org/packages/8d/1b/6da9a89583ce7b23ac611f183ae4843cd3a6cf54f079549b0e8c14031e73/pyarrow-23.0.1-cp314-cp314-macosx_12_0_arm64.whl", hash = "sha256:5df1161da23636a70838099d4aaa65142777185cc0cdba4037a18cee7d8db9ca", size = 34238755, upload-time = "2026-02-16T10:12:32.819Z" },
-    { url = "https://files.pythonhosted.org/packages/ae/b5/d58a241fbe324dbaeb8df07be6af8752c846192d78d2272e551098f74e88/pyarrow-23.0.1-cp314-cp314-macosx_12_0_x86_64.whl", hash = "sha256:fa8e51cb04b9f8c9c5ace6bab63af9a1f88d35c0d6cbf53e8c17c098552285e1", size = 35847826, upload-time = "2026-02-16T10:12:38.949Z" },
-    { url = "https://files.pythonhosted.org/packages/54/a5/8cbc83f04aba433ca7b331b38f39e000efd9f0c7ce47128670e737542996/pyarrow-23.0.1-cp314-cp314-manylinux_2_28_aarch64.whl", hash = "sha256:0b95a3994f015be13c63148fef8832e8a23938128c185ee951c98908a696e0eb", size = 44536859, upload-time = "2026-02-16T10:12:45.467Z" },
-    { url = "https://files.pythonhosted.org/packages/36/2e/c0f017c405fcdc252dbccafbe05e36b0d0eb1ea9a958f081e01c6972927f/pyarrow-23.0.1-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:4982d71350b1a6e5cfe1af742c53dfb759b11ce14141870d05d9e540d13bc5d1", size = 47614443, upload-time = "2026-02-16T10:12:55.525Z" },
-    { url = "https://files.pythonhosted.org/packages/af/6b/2314a78057912f5627afa13ba43809d9d653e6630859618b0fd81a4e0759/pyarrow-23.0.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:c250248f1fe266db627921c89b47b7c06fee0489ad95b04d50353537d74d6886", size = 48232991, upload-time = "2026-02-16T10:13:04.729Z" },
-    { url = "https://files.pythonhosted.org/packages/40/f2/1bcb1d3be3460832ef3370d621142216e15a2c7c62602a4ea19ec240dd64/pyarrow-23.0.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:5f4763b83c11c16e5f4c15601ba6dfa849e20723b46aa2617cb4bffe8768479f", size = 50645077, upload-time = "2026-02-16T10:13:14.147Z" },
-    { url = "https://files.pythonhosted.org/packages/eb/3f/b1da7b61cd66566a4d4c8383d376c606d1c34a906c3f1cb35c479f59d1aa/pyarrow-23.0.1-cp314-cp314-win_amd64.whl", hash = "sha256:3a4c85ef66c134161987c17b147d6bffdca4566f9a4c1d81a0a01cdf08414ea5", size = 28234271, upload-time = "2026-02-16T10:14:09.397Z" },
-    { url = "https://files.pythonhosted.org/packages/b5/78/07f67434e910a0f7323269be7bfbf58699bd0c1d080b18a1ab49ba943fe8/pyarrow-23.0.1-cp314-cp314t-macosx_12_0_arm64.whl", hash = "sha256:17cd28e906c18af486a499422740298c52d7c6795344ea5002a7720b4eadf16d", size = 34488692, upload-time = "2026-02-16T10:13:21.541Z" },
-    { url = "https://files.pythonhosted.org/packages/50/76/34cf7ae93ece1f740a04910d9f7e80ba166b9b4ab9596a953e9e62b90fe1/pyarrow-23.0.1-cp314-cp314t-macosx_12_0_x86_64.whl", hash = "sha256:76e823d0e86b4fb5e1cf4a58d293036e678b5a4b03539be933d3b31f9406859f", size = 35964383, upload-time = "2026-02-16T10:13:28.63Z" },
-    { url = "https://files.pythonhosted.org/packages/46/90/459b827238936d4244214be7c684e1b366a63f8c78c380807ae25ed92199/pyarrow-23.0.1-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:a62e1899e3078bf65943078b3ad2a6ddcacf2373bc06379aac61b1e548a75814", size = 44538119, upload-time = "2026-02-16T10:13:35.506Z" },
-    { url = "https://files.pythonhosted.org/packages/28/a1/93a71ae5881e99d1f9de1d4554a87be37da11cd6b152239fb5bd924fdc64/pyarrow-23.0.1-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:df088e8f640c9fae3b1f495b3c64755c4e719091caf250f3a74d095ddf3c836d", size = 47571199, upload-time = "2026-02-16T10:13:42.504Z" },
-    { url = "https://files.pythonhosted.org/packages/88/a3/d2c462d4ef313521eaf2eff04d204ac60775263f1fb08c374b543f79f610/pyarrow-23.0.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:46718a220d64677c93bc243af1d44b55998255427588e400677d7192671845c7", size = 48259435, upload-time = "2026-02-16T10:13:49.226Z" },
-    { url = "https://files.pythonhosted.org/packages/cc/f1/11a544b8c3d38a759eb3fbb022039117fd633e9a7b19e4841cc3da091915/pyarrow-23.0.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:a09f3876e87f48bc2f13583ab551f0379e5dfb83210391e68ace404181a20690", size = 50629149, upload-time = "2026-02-16T10:13:57.238Z" },
-    { url = "https://files.pythonhosted.org/packages/50/f2/c0e76a0b451ffdf0cf788932e182758eb7558953f4f27f1aff8e2518b653/pyarrow-23.0.1-cp314-cp314t-win_amd64.whl", hash = "sha256:527e8d899f14bd15b740cd5a54ad56b7f98044955373a17179d5956ddb93d9ce", size = 28365807, upload-time = "2026-02-16T10:14:03.892Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/d3/a1abf004482026ddc17f4503db227787fa3cfe41ec5091ff20e4fea55e57/pyarrow-24.0.0-cp313-cp313-macosx_12_0_arm64.whl", hash = "sha256:02b001b3ed4723caa44f6cd1af2d5c86aa2cf9971dacc2ffa55b21237713dfba", size = 34976759, upload-time = "2026-04-21T10:48:07.258Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/4a/34f0a36d28a2dd32225301b79daad44e243dc1a2bb77d43b60749be255c4/pyarrow-24.0.0-cp313-cp313-macosx_12_0_x86_64.whl", hash = "sha256:04920d6a71aabd08a0417709efce97d45ea8e6fb733d9ca9ecffb13c67839f68", size = 36658471, upload-time = "2026-04-21T10:48:13.347Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/78/543b94712ae8bb1a6023bcc1acf1a740fbff8286747c289cd9468fced2a5/pyarrow-24.0.0-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:a964266397740257f16f7bb2e4f08a0c81454004beab8ff59dd531b73610e9f2", size = 45675981, upload-time = "2026-04-21T10:48:20.201Z" },
+    { url = "https://files.pythonhosted.org/packages/84/9f/8fb7c222b100d314137fa40ec050de56cd8c6d957d1cfff685ce72f15b17/pyarrow-24.0.0-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:6f066b179d68c413374294bc1735f68475457c933258df594443bb9d88ddc2a0", size = 48859172, upload-time = "2026-04-21T10:48:27.541Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/d3/1ea72538e6c8b3b475ed78d1049a2c518e655761ea50fe1171fc855fcab7/pyarrow-24.0.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:1183baeb14c5f587b1ec52831e665718ce632caab84b7cd6b85fd44f96114495", size = 49385733, upload-time = "2026-04-21T10:48:34.7Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/be/c3d8b06a1ba35f2260f8e1f771abbee7d5e345c0937aab90675706b1690a/pyarrow-24.0.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:806f24b4085453c197a5078218d1ee08783ebbba271badd153d1ae22a3ee804f", size = 51934335, upload-time = "2026-04-21T10:48:42.099Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/62/89e07a1e7329d2cde3e3c6994ba0839a24977a2beda8be6005ea3d860b99/pyarrow-24.0.0-cp313-cp313-win_amd64.whl", hash = "sha256:e4505fc6583f7b05ab854934896bcac8253b04ac1171a77dfb73efef92076d91", size = 27271748, upload-time = "2026-04-21T10:49:42.532Z" },
+    { url = "https://files.pythonhosted.org/packages/17/1a/cff3a59f80b5b1658549d46611b67163f65e0664431c076ad728bf9d5af4/pyarrow-24.0.0-cp313-cp313t-macosx_12_0_arm64.whl", hash = "sha256:1a4e45017efbf115032e4475ee876d525e0e36c742214fbe405332480ecd6275", size = 35238554, upload-time = "2026-04-21T10:48:48.526Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/99/cce0f42a327bfef2c420fb6078a3eb834826e5d6697bf3009fe11d2ad051/pyarrow-24.0.0-cp313-cp313t-macosx_12_0_x86_64.whl", hash = "sha256:7986f1fa71cee060ad00758bcc79d3a93bab8559bf978fab9e53472a2e25a17b", size = 36782301, upload-time = "2026-04-21T10:48:55.181Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/66/8e560d5ff6793ca29aca213c53eec0dd482dd46cb93b2819e5aab52e4252/pyarrow-24.0.0-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:d3e0b61e8efb24ed38898e5cdc5fffa9124be480008d401a1f8071500494ae42", size = 45721929, upload-time = "2026-04-21T10:49:03.676Z" },
+    { url = "https://files.pythonhosted.org/packages/27/0c/a26e25505d030716e078d9f16eb74973cbf0b33b672884e9f9da1c83b871/pyarrow-24.0.0-cp313-cp313t-manylinux_2_28_x86_64.whl", hash = "sha256:55a3bc1e3df3b5567b7d27ef551b2283f0c68a5e86f1cd56abc569da4f31335b", size = 48825365, upload-time = "2026-04-21T10:49:11.714Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/eb/771f9ecb0c65e73fe9dccdd1717901b9594f08c4515d000c7c62df573811/pyarrow-24.0.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:641f795b361874ac9da5294f8f443dfdbee355cf2bd9e3b8d97aaac2306b9b37", size = 49451819, upload-time = "2026-04-21T10:49:21.474Z" },
+    { url = "https://files.pythonhosted.org/packages/48/da/61ae89a88732f5a785646f3ec6125dbb640fa98a540eb2b9889caa561403/pyarrow-24.0.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:8adc8e6ce5fccf5dc707046ae4914fd537def529709cc0d285d37a7f9cd442ca", size = 51909252, upload-time = "2026-04-21T10:49:31.164Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/1a/8dd5cafab7b66573fa91c03d06d213356ad4edd71813aa75e08ce2b3a844/pyarrow-24.0.0-cp313-cp313t-win_amd64.whl", hash = "sha256:9b18371ad2f44044b81a8d23bc2d8a9b6a6226dca775e8e16cfee640473d6c5d", size = 27388127, upload-time = "2026-04-21T10:49:37.334Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/80/d022a34ff05d2cbedd8ccf841fc1f532ecfa9eb5ed1711b56d0e0ea71fc9/pyarrow-24.0.0-cp314-cp314-macosx_12_0_arm64.whl", hash = "sha256:1cc9057f0319e26333b357e17f3c2c022f1a83739b48a88b25bfd5fa2dc18838", size = 35007997, upload-time = "2026-04-21T10:49:48.796Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/ff/f01485fda6f4e5d441afb8dd5e7681e4db18826c1e271852f5d3957d6a80/pyarrow-24.0.0-cp314-cp314-macosx_12_0_x86_64.whl", hash = "sha256:e6f1278ee4785b6db21229374a1c9e54ec7c549de5d1efc9630b6207de7e170b", size = 36678720, upload-time = "2026-04-21T10:49:55.858Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/c2/2d2d5fea814237923f71b36495211f20b43a1576f9a4d6da7e751a64ec6f/pyarrow-24.0.0-cp314-cp314-manylinux_2_28_aarch64.whl", hash = "sha256:adbbedc55506cbdabb830890444fb856bfb0060c46c6f8026c6c2f2cf86ae795", size = 45741852, upload-time = "2026-04-21T10:50:04.624Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/3a/28ba9c1c1ebdbb5f1b94dfebb46f207e52e6a554b7fe4132540fde29a3a0/pyarrow-24.0.0-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:ae8a1145af31d903fa9bb166824d7abe9b4681a000b0159c9fb99c11bc11ad26", size = 48889852, upload-time = "2026-04-21T10:50:12.293Z" },
+    { url = "https://files.pythonhosted.org/packages/df/51/4a389acfd31dca009f8fb82d7f510bb4130f2b3a8e18cf00194d0687d8ac/pyarrow-24.0.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:d7027eba1df3b2069e2e8d80f644fa0918b68c46432af3d088ddd390d063ecde", size = 49445207, upload-time = "2026-04-21T10:50:20.677Z" },
+    { url = "https://files.pythonhosted.org/packages/19/4b/0bab2b23d2ae901b1b9a03c0efd4b2d070256f8ce3fc43f6e58c167b2081/pyarrow-24.0.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:e56a1ffe9bf7b727432b89104cc0849c21582949dd7bdcb34f17b2001a351a76", size = 51954117, upload-time = "2026-04-21T10:50:29.14Z" },
+    { url = "https://files.pythonhosted.org/packages/29/88/f4e9145da0417b3d2c12035a8492b35ff4a3dbc653e614fcfb51d9dedb38/pyarrow-24.0.0-cp314-cp314-win_amd64.whl", hash = "sha256:38be1808cdd068605b787e6ca9119b27eb275a0234e50212c3492331680c3b1e", size = 28001155, upload-time = "2026-04-21T10:51:22.337Z" },
+    { url = "https://files.pythonhosted.org/packages/79/4f/46a49a63f43526da895b1a45bbb51d5baf8e4d77159f8528fc3e5490007f/pyarrow-24.0.0-cp314-cp314t-macosx_12_0_arm64.whl", hash = "sha256:418e48ce50a45a6a6c73c454677203a9c75c966cb1e92ca3370959185f197a05", size = 35250387, upload-time = "2026-04-21T10:50:35.552Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/da/d5e0cd5ef00796922404806d5f00325cdadc3441ce2c13fe7115f2df9a64/pyarrow-24.0.0-cp314-cp314t-macosx_12_0_x86_64.whl", hash = "sha256:2f16197705a230a78270cdd4ea8a1d57e86b2fdcbc34a1f6aebc72e65c986f9a", size = 36797102, upload-time = "2026-04-21T10:50:42.417Z" },
+    { url = "https://files.pythonhosted.org/packages/34/c7/5904145b0a593a05236c882933d439b5720f0a145381179063722fbfc123/pyarrow-24.0.0-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:fb24ac194bfc5e86839d7dcd52092ee31e5fe6733fe11f5e3b06ef0812b20072", size = 45745118, upload-time = "2026-04-21T10:50:49.324Z" },
+    { url = "https://files.pythonhosted.org/packages/13/d3/cca42fe166d1c6e4d5b80e530b7949104d10e17508a90ae202dac205ce2a/pyarrow-24.0.0-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:9700ebd9a51f5895ce75ff4ac4b3c47a7d4b42bc618be8e713e5d56bacf5f931", size = 48844765, upload-time = "2026-04-21T10:50:55.579Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/49/942c3b79878ba928324d1e17c274ed84581db8c0a749b24bcf4cbdf15bd3/pyarrow-24.0.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:d8ddd2768da81d3ee08cfea9b597f4abb4e8e1dc8ae7e204b608d23a0d3ab699", size = 49471890, upload-time = "2026-04-21T10:51:02.439Z" },
+    { url = "https://files.pythonhosted.org/packages/76/97/ff71431000a75d84135a1ace5ca4ba11726a231a8007bbb320a4c54075d5/pyarrow-24.0.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:61a3d7eaa97a14768b542f3d284dc6400dd2470d9f080708b13cd46b6ae18136", size = 51932250, upload-time = "2026-04-21T10:51:10.576Z" },
+    { url = "https://files.pythonhosted.org/packages/51/be/6f79d55816d5c22557cf27533543d5d70dfe692adfbee4b99f2760674f38/pyarrow-24.0.0-cp314-cp314t-win_amd64.whl", hash = "sha256:c91d00057f23b8d353039520dc3a6c09d8608164c692e9f59a175a42b2ae0c19", size = 28131282, upload-time = "2026-04-21T10:51:16.815Z" },
 ]
 
 [[package]]
@@ -3522,14 +3548,14 @@ wheels = [
 
 [[package]]
 name = "pytest-asyncio"
-version = "1.3.0"
+version = "1.4.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pytest" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/90/2c/8af215c0f776415f3590cac4f9086ccefd6fd463befeae41cd4d3f193e5a/pytest_asyncio-1.3.0.tar.gz", hash = "sha256:d7f52f36d231b80ee124cd216ffb19369aa168fc10095013c6b014a34d3ee9e5", size = 50087, upload-time = "2025-11-10T16:07:47.256Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/43/7c/d36d04db312ecf4298932ef77e6e4a9e8ad017906e24e34f0b0c361a2473/pytest_asyncio-1.4.0.tar.gz", hash = "sha256:c6c0d2259945122819f171a32ecea2c349ead889ee28176caaf492143424be42", size = 58514, upload-time = "2026-05-26T09:56:04.083Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e5/35/f8b19922b6a25bc0880171a2f1a003eaeb93657475193ab516fd87cac9da/pytest_asyncio-1.3.0-py3-none-any.whl", hash = "sha256:611e26147c7f77640e6d0a92a38ed17c3e9848063698d5c93d5aa7aa11cebff5", size = 15075, upload-time = "2025-11-10T16:07:45.537Z" },
+    { url = "https://files.pythonhosted.org/packages/03/e2/08a497ef684b88559c9cc5f4ad53a37e7b99e727094a86d6ea32536d5d3c/pytest_asyncio-1.4.0-py3-none-any.whl", hash = "sha256:933ca923a23075a87fb7070c0ec272a6848489824d887c85c812670932835aa1", size = 16930, upload-time = "2026-05-26T09:56:02.576Z" },
 ]
 
 [[package]]
@@ -3560,15 +3586,15 @@ wheels = [
 
 [[package]]
 name = "python-discovery"
-version = "1.3.1"
+version = "1.4.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "filelock" },
     { name = "platformdirs" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/48/60/e88788207d81e46362cfbef0d4aaf4c0f49efc3c12d4c3fa3f542c34ebec/python_discovery-1.3.1.tar.gz", hash = "sha256:62f6db28064c9613e7ca76cb3f00c38c839a07c31c00dfe7ed0986493d2150a6", size = 68011, upload-time = "2026-05-12T20:53:36.336Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a6/12/38c1a0b1e64806780c9563e3fc9f6e472251839662587cfbe9bfaf2ae10a/python_discovery-1.4.0.tar.gz", hash = "sha256:eb8bc7daad3c226c147e45bb4e970a1feb1bf4048ee178e6db59e197b8010ce3", size = 68455, upload-time = "2026-05-28T01:15:37.639Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b7/6f/a05a317a66fee0aad270011461f1a63a453ed12471249f172f7d2e2bc7b4/python_discovery-1.3.1-py3-none-any.whl", hash = "sha256:ed188687ebb3b82c01a17cd5ac62fc94d9f6487a7f1a0f9dfe89753fec91039c", size = 33185, upload-time = "2026-05-12T20:53:34.969Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/8d/3d316429f65029532bb1e28ff77b797d86b5ac3915bb44ca4e19aa283d43/python_discovery-1.4.0-py3-none-any.whl", hash = "sha256:26ed78d703e234879a66244c7d4114563fb13ec5cd30a2d1357e5fb4850782da", size = 33217, upload-time = "2026-05-28T01:15:36.573Z" },
 ]
 
 [[package]]
@@ -3821,39 +3847,39 @@ wheels = [
 
 [[package]]
 name = "ruff"
-version = "0.15.14"
+version = "0.15.15"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/dc/8a/8bce2894573e9dae6ff4d77fe34ad727d79b9e6238ad288c5638990d90f6/ruff-0.15.14.tar.gz", hash = "sha256:48e866b165be4a9bdbf310f7d3c9a07edef2fe8cd63ffeb4e00bb590506ebf9f", size = 4700910, upload-time = "2026-05-21T14:34:55.177Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/84/6f/a76f7d96e5c962f5b69cee865e49c15c1116897c01990faa8a57edb62e7f/ruff-0.15.15.tar.gz", hash = "sha256:b8dff018130b46d8e5bf0f926ef6b60cf871d6d5ae45fc9334e09632daa741d6", size = 4706985, upload-time = "2026-05-28T14:16:57.784Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b9/c8/74a92c6ff9fcfb4f1f947126d3ebee8389276e161ecc85de5bda7cda51bd/ruff-0.15.14-py3-none-linux_armv6l.whl", hash = "sha256:8dd2db9416e487c8d4b01fa7056bb02c4d05969d4f8d17a08c229c2f4ff3c108", size = 10739177, upload-time = "2026-05-21T14:34:37.332Z" },
-    { url = "https://files.pythonhosted.org/packages/45/91/254a35c20acc38a7223c9d2d594af12e794432464f2cdeb52af1dc4a892d/ruff-0.15.14-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:be4ff55af755bd71a00ab3dc6bd7ffc467bd76e0df6881e286c2e3d23e8fb43b", size = 11144969, upload-time = "2026-05-21T14:34:43.978Z" },
-    { url = "https://files.pythonhosted.org/packages/56/9e/d13e40f83b8d0a94430e6778ce1d94a43b38cf2efe63278bdd2b4c65abbf/ruff-0.15.14-py3-none-macosx_11_0_arm64.whl", hash = "sha256:48d5909d7d06276ce7dde6d32bfa4b0d4cb2651145cd8ee4b440722cbc77832f", size = 10478207, upload-time = "2026-05-21T14:34:48.378Z" },
-    { url = "https://files.pythonhosted.org/packages/8d/f1/b15a7839fa4f332f8acec78e20564f26bb2d866e3d21710b877fd0263000/ruff-0.15.14-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ca8cbfa94c4f90984a67561978602746d4cd27103568f745fa90eee3f0d4107d", size = 10818459, upload-time = "2026-05-21T14:34:22.318Z" },
-    { url = "https://files.pythonhosted.org/packages/45/33/53d651177f84f94b400a0e27f8824eeada3dddc9d5ee8aeb048f4352a520/ruff-0.15.14-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:9a6bbc0333f1ab053423bcbf6226477d266ca7cec7738c4c8e3f55647803f3c4", size = 10541800, upload-time = "2026-05-21T14:34:20.209Z" },
-    { url = "https://files.pythonhosted.org/packages/b8/a6/868f87e0bf9786ed24b5d0d0ad8676b8a94fd1912f42cddf9cfc7857818a/ruff-0.15.14-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:8a24a4f7605d7003a6674d4387651effd939dead3fddd0f36561eb77a9a2e542", size = 11342149, upload-time = "2026-05-21T14:34:46.365Z" },
-    { url = "https://files.pythonhosted.org/packages/a7/8b/38cd5c19faffdcc05a408d2b78edccc69492ab9720eadb49ea15ef80d768/ruff-0.15.14-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:049b5326e53ed80978f2fc041a280603f69dd6b0c95464342a2bb4572d9d9e2f", size = 12212563, upload-time = "2026-05-21T14:34:28.579Z" },
-    { url = "https://files.pythonhosted.org/packages/3e/4d/a3c5b874a556d5731e3e657aaf04311bb76f0a5c3ec220ed43051be6b64b/ruff-0.15.14-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:d4ed42e6696c8dfa5f06728e6441993901f548eb92d73bc472cb5a38d1395fbf", size = 11493299, upload-time = "2026-05-21T14:34:41.836Z" },
-    { url = "https://files.pythonhosted.org/packages/1e/c0/56472c251d09858a53e51efbd485b09e1995d8731668b76d52e5dd6ee0f1/ruff-0.15.14-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:715c543cf450c4888251f91c52f1942a800541d9bddd7ac060aa4e6b77ae7cba", size = 11455931, upload-time = "2026-05-21T14:34:57.276Z" },
-    { url = "https://files.pythonhosted.org/packages/2c/4a/e2e7b4d8dbf233d4eace59c75bc3435fa6d8bd3bae82d351d4e4300c0fd1/ruff-0.15.14-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:72ebab6013ec887d439d8b7593737a0a4ffb06d45d209d4e4bf2e92813082d3f", size = 11400794, upload-time = "2026-05-21T14:34:39.773Z" },
-    { url = "https://files.pythonhosted.org/packages/97/c7/83c0539fe34c3e09136204d1e75d6052492364e0b3cb05e9465423f567d7/ruff-0.15.14-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:49072d36abdbe97a8dd7f480afe9c675699c0c495d4c84076e2c1203c4550581", size = 10804759, upload-time = "2026-05-21T14:34:31.045Z" },
-    { url = "https://files.pythonhosted.org/packages/86/a6/18f2bfc095a2ab4a78745644e428205532ce6653a5d0fa8501572891534d/ruff-0.15.14-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:958522aee105068640c2c2ceae08f413ae44d922f52a1374ac13d6a96032fc93", size = 10539517, upload-time = "2026-05-21T14:34:53.064Z" },
-    { url = "https://files.pythonhosted.org/packages/54/3a/5a8b3b69c654d4e4bf1d246ac5b49cbcdac6eaab6905925f8915f31e3b80/ruff-0.15.14-py3-none-musllinux_1_2_i686.whl", hash = "sha256:f3707da619a143a2e8830e2abab8224478d69ace2d28cb6c20543ae97c36bf61", size = 11065169, upload-time = "2026-05-21T14:34:24.484Z" },
-    { url = "https://files.pythonhosted.org/packages/ed/c5/8864e4e7925b836ea354b31d57641ec03830564e281a8b6f061f8c3e0ec1/ruff-0.15.14-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:bb01d645694e3ec0102105d07ef2d53703970407d59c04e59d3ba0b7a1d53553", size = 11560214, upload-time = "2026-05-21T14:34:50.975Z" },
-    { url = "https://files.pythonhosted.org/packages/36/38/012bf76752e1f89ed50b77b99532d90f3a3e287bc7918e1fc0948ac866ac/ruff-0.15.14-py3-none-win32.whl", hash = "sha256:6d0c1ad2a0ab718d39b6d8fd2217981ce4d625cd96a720095f798fb47d8b13e6", size = 10805548, upload-time = "2026-05-21T14:34:33.453Z" },
-    { url = "https://files.pythonhosted.org/packages/d1/b7/4ea2c170f10ad760fff2a5250beb18897719dc8b52b53a24cddbb9dd3f19/ruff-0.15.14-py3-none-win_amd64.whl", hash = "sha256:802342981e056db3851a7836e5b070f8f15f67d4a685ae2a6160939d364b2902", size = 11939523, upload-time = "2026-05-21T14:34:18.077Z" },
-    { url = "https://files.pythonhosted.org/packages/62/d5/bc97ff895ec35cf3925d4bd60f3b39d822f377a446906ec9bcc87405e59b/ruff-0.15.14-py3-none-win_arm64.whl", hash = "sha256:ff47b90a9ef6a40c9e2f3b479c1fb78531adf055b94c1eba0a7ba04b31951826", size = 11208607, upload-time = "2026-05-21T14:34:26.525Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/9d/3a45c05b8ab04b4705989de70a79008e27c8003296a0feaee9edc18dd7e9/ruff-0.15.15-py3-none-linux_armv6l.whl", hash = "sha256:cf93e5388f412e1b108b1f8b34a6e036b70fe8aff89393befad96fe48670311b", size = 10710652, upload-time = "2026-05-28T14:16:06.701Z" },
+    { url = "https://files.pythonhosted.org/packages/05/66/da974431624bf3b49f6ee1f9543c02d929ff1cba78b0d5a79c38cf21f744/ruff-0.15.15-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:ac5a646d1f6a7dadd5d50842dae2c1f9862ac887ef5d1b1375e02def791fde6e", size = 11096615, upload-time = "2026-05-28T14:16:23.313Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/09/7443452e5d290230a712103f2fdceeef7184f3ec99a2bd01c8be78aaceb5/ruff-0.15.15-py3-none-macosx_11_0_arm64.whl", hash = "sha256:77d955a431430c66f72dd94e379ad38a16daea3d25094872ac4edf9e797be530", size = 10436683, upload-time = "2026-05-28T14:16:40.974Z" },
+    { url = "https://files.pythonhosted.org/packages/53/01/d330c26a57fa4f3943a14424904027428315b700fe4d14a84bb123a649e5/ruff-0.15.15-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7614ee79c69788cf6cedd568069ade9cecc22a1ad20494efe8d0c9ebb4b622d4", size = 10769064, upload-time = "2026-05-28T14:16:28.905Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/85/cc8770f8bdff541b1da8392d1634141fe4a0e3f4ee596605959b7906c27f/ruff-0.15.15-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:3cdb1679e06a1f6b47bc384714ae96f6e2fb65ca441eb78c43d2ca554176ce1f", size = 10511987, upload-time = "2026-05-28T14:16:43.732Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/29/8c190c1472b63013583ba391f3342036e02010544c1270455ed8e519bdf3/ruff-0.15.15-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:2728b93d7b23a603ea2c0ac6eb73d760bd38ec9de35f35fb41e18f7a3fee7622", size = 11275100, upload-time = "2026-05-28T14:16:55.244Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/6b/7e145ce2cc8e63d6834eca03d83a0e18d121def5c69f91b4cf4011ed4879/ruff-0.15.15-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:be582fcc0db438902c7792b08d6ddf6c9b9e21addaa10092c2c741cfb09e5a45", size = 12176903, upload-time = "2026-05-28T14:16:14.368Z" },
+    { url = "https://files.pythonhosted.org/packages/80/a3/d5974637f68e451f7fadf015cf3101d1cd7d8ba5027cffe0b9e3826ebe6b/ruff-0.15.15-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:7aa77465b8ecaf1a27bea098d696f7fed5e1eccbd10b321b682d6de586ae5627", size = 11404550, upload-time = "2026-05-28T14:16:20.138Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/1c/e6e5e568f22be4fb05d6244234aba384c06b451252453b821e1a529263cf/ruff-0.15.15-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:48decfa11d740de4889de623be1463308346312f2409a56e24aa280c86162dc4", size = 11382027, upload-time = "2026-05-28T14:16:46.615Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/01/170921b49fcd2e8858825593f91cf7146c3e40a5c3e6df763e4bb0484dde/ruff-0.15.15-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:a5015088452ca0081387063649ec67f06d3d1d6b8b936a1f836b5e9657ecd48c", size = 11366041, upload-time = "2026-05-28T14:16:26.247Z" },
+    { url = "https://files.pythonhosted.org/packages/87/54/a7bad711d7de93254e15e06a4c375b89a03d18de45d3e5dcc86a4472fb1a/ruff-0.15.15-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:f5294aab6356c81600fcdea3a62bb1b924dfd5e91767c12318d3f68f86af57cd", size = 10741795, upload-time = "2026-05-28T14:16:17.11Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/31/38c075963668f8b41c6914ee0f6f318727fbe30ab9145cb29e6df464c5fa/ruff-0.15.15-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:db5bd4d802415cca656dc1616070b725952d6ae95eb5d4831e49fbd94a38f75f", size = 10511117, upload-time = "2026-05-28T14:16:31.767Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/96/6ff689e1f7e375d1d97075eca022f74c2bab59554a432fe4d2e6f091986a/ruff-0.15.15-py3-none-musllinux_1_2_i686.whl", hash = "sha256:587a6278ed42059191c1a466e490bd7930fb50bd2e255398bc29616c895a61cb", size = 10994867, upload-time = "2026-05-28T14:16:35.149Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/c2/5dce0ab9f92a8d534fa62b9bf9caca3eddb8c1a81b616f5e195ada4f0d6e/ruff-0.15.15-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:df0c1c084f5f4be9812f61518a45c440d3c30d69ce4bf6c5270e66d38338f02a", size = 11482101, upload-time = "2026-05-28T14:16:49.598Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/c0/1003b60edd697c649faf61f1a34094b1abb38fb3d1181e3f895781250a08/ruff-0.15.15-py3-none-win32.whl", hash = "sha256:29428ea79694afbe756d45fd59b36f22b6b020dc0443cf7de0173046236964b9", size = 10716774, upload-time = "2026-05-28T14:16:52.337Z" },
+    { url = "https://files.pythonhosted.org/packages/02/a8/1269eddd6945a06c23f055ef7848886e37cf9d6a8bebb386a3115f01470c/ruff-0.15.15-py3-none-win_amd64.whl", hash = "sha256:8df0323902e15e24bc4bf246da830573d3cf3352bd0b9a164eab335d111ff4a4", size = 11868463, upload-time = "2026-05-28T14:16:11.333Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/b2/920464c907b191e37469d477a1aa8bc048b8f36c4c1610dfa4ab87b39e18/ruff-0.15.15-py3-none-win_arm64.whl", hash = "sha256:3c8ceca6792f38196b8f589bc92eccd03eef286602da92e5dc05cc42ef6441b7", size = 11138498, upload-time = "2026-05-28T14:16:38.425Z" },
 ]
 
 [[package]]
 name = "s3transfer"
-version = "0.17.0"
+version = "0.18.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "botocore" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/9b/ec/7c692cde9125b77e84b307354d4fb705f98b8ccad59a036d5957ca75bfc3/s3transfer-0.17.0.tar.gz", hash = "sha256:9edeb6d1c3c2f89d6050348548834ad8289610d886e5bf7b7207728bd43ce33a", size = 155337, upload-time = "2026-04-29T22:07:36.33Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e0/1f/12417f7f493fc45e1f9fd5d4a9b6c125cf8d2cf3f8ddbdfab3e76406e9d6/s3transfer-0.18.0.tar.gz", hash = "sha256:3760b8b7ec1315da54048b2d626276732bee4300d054d492d4e1d43e20d4ecbd", size = 160560, upload-time = "2026-05-28T19:39:09.124Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/87/72/c6c32d2b657fa3dad1de340254e14390b1e334ce38268b7ad51abda3c8c2/s3transfer-0.17.0-py3-none-any.whl", hash = "sha256:ce3801712acf4ad3e89fb9990df97b4972e93f4b3b0004d214be5bce12814c20", size = 86811, upload-time = "2026-04-29T22:07:34.966Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/58/a58fc997655386daa2e25784e30c288aa3e3819e401f77029ee4899fb55a/s3transfer-0.18.0-py3-none-any.whl", hash = "sha256:239c13b09e65ad0346e1be7348b8a202dcad44ac7ea7c6eb858fc881dce739b6", size = 88572, upload-time = "2026-05-28T19:39:07.999Z" },
 ]
 
 [[package]]
@@ -3880,40 +3906,35 @@ wheels = [
 
 [[package]]
 name = "scikit-learn"
-version = "1.8.0"
+version = "1.9.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "joblib" },
+    { name = "narwhals" },
     { name = "numpy" },
     { name = "scipy" },
     { name = "threadpoolctl" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/0e/d4/40988bf3b8e34feec1d0e6a051446b1f66225f8529b9309becaeef62b6c4/scikit_learn-1.8.0.tar.gz", hash = "sha256:9bccbb3b40e3de10351f8f5068e105d0f4083b1a65fa07b6634fbc401a6287fd", size = 7335585, upload-time = "2025-12-10T07:08:53.618Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/fa/6f/37092bdb25f712817231799fc5674d8e704066a8a70c1d2d40517e18b4ab/scikit_learn-1.9.0.tar.gz", hash = "sha256:8833266989d3a5110178a9fae30783675460724d0e1efb13b14901d2c660c557", size = 7750767, upload-time = "2026-06-02T11:54:32.706Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/03/aa/e22e0768512ce9255eba34775be2e85c2048da73da1193e841707f8f039c/scikit_learn-1.8.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:0d6ae97234d5d7079dc0040990a6f7aeb97cb7fa7e8945f1999a429b23569e0a", size = 8513770, upload-time = "2025-12-10T07:08:03.251Z" },
-    { url = "https://files.pythonhosted.org/packages/58/37/31b83b2594105f61a381fc74ca19e8780ee923be2d496fcd8d2e1147bd99/scikit_learn-1.8.0-cp313-cp313-macosx_12_0_arm64.whl", hash = "sha256:edec98c5e7c128328124a029bceb09eda2d526997780fef8d65e9a69eead963e", size = 8044458, upload-time = "2025-12-10T07:08:05.336Z" },
-    { url = "https://files.pythonhosted.org/packages/2d/5a/3f1caed8765f33eabb723596666da4ebbf43d11e96550fb18bdec42b467b/scikit_learn-1.8.0-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:74b66d8689d52ed04c271e1329f0c61635bcaf5b926db9b12d58914cdc01fe57", size = 8610341, upload-time = "2025-12-10T07:08:07.732Z" },
-    { url = "https://files.pythonhosted.org/packages/38/cf/06896db3f71c75902a8e9943b444a56e727418f6b4b4a90c98c934f51ed4/scikit_learn-1.8.0-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8fdf95767f989b0cfedb85f7ed8ca215d4be728031f56ff5a519ee1e3276dc2e", size = 8900022, upload-time = "2025-12-10T07:08:09.862Z" },
-    { url = "https://files.pythonhosted.org/packages/1c/f9/9b7563caf3ec8873e17a31401858efab6b39a882daf6c1bfa88879c0aa11/scikit_learn-1.8.0-cp313-cp313-win_amd64.whl", hash = "sha256:2de443b9373b3b615aec1bb57f9baa6bb3a9bd093f1269ba95c17d870422b271", size = 7989409, upload-time = "2025-12-10T07:08:12.028Z" },
-    { url = "https://files.pythonhosted.org/packages/49/bd/1f4001503650e72c4f6009ac0c4413cb17d2d601cef6f71c0453da2732fc/scikit_learn-1.8.0-cp313-cp313-win_arm64.whl", hash = "sha256:eddde82a035681427cbedded4e6eff5e57fa59216c2e3e90b10b19ab1d0a65c3", size = 7619760, upload-time = "2025-12-10T07:08:13.688Z" },
-    { url = "https://files.pythonhosted.org/packages/d2/7d/a630359fc9dcc95496588c8d8e3245cc8fd81980251079bc09c70d41d951/scikit_learn-1.8.0-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:7cc267b6108f0a1499a734167282c00c4ebf61328566b55ef262d48e9849c735", size = 8826045, upload-time = "2025-12-10T07:08:15.215Z" },
-    { url = "https://files.pythonhosted.org/packages/cc/56/a0c86f6930cfcd1c7054a2bc417e26960bb88d32444fe7f71d5c2cfae891/scikit_learn-1.8.0-cp313-cp313t-macosx_12_0_arm64.whl", hash = "sha256:fe1c011a640a9f0791146011dfd3c7d9669785f9fed2b2a5f9e207536cf5c2fd", size = 8420324, upload-time = "2025-12-10T07:08:17.561Z" },
-    { url = "https://files.pythonhosted.org/packages/46/1e/05962ea1cebc1cf3876667ecb14c283ef755bf409993c5946ade3b77e303/scikit_learn-1.8.0-cp313-cp313t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:72358cce49465d140cc4e7792015bb1f0296a9742d5622c67e31399b75468b9e", size = 8680651, upload-time = "2025-12-10T07:08:19.952Z" },
-    { url = "https://files.pythonhosted.org/packages/fe/56/a85473cd75f200c9759e3a5f0bcab2d116c92a8a02ee08ccd73b870f8bb4/scikit_learn-1.8.0-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:80832434a6cc114f5219211eec13dcbc16c2bac0e31ef64c6d346cde3cf054cb", size = 8925045, upload-time = "2025-12-10T07:08:22.11Z" },
-    { url = "https://files.pythonhosted.org/packages/cc/b7/64d8cfa896c64435ae57f4917a548d7ac7a44762ff9802f75a79b77cb633/scikit_learn-1.8.0-cp313-cp313t-win_amd64.whl", hash = "sha256:ee787491dbfe082d9c3013f01f5991658b0f38aa8177e4cd4bf434c58f551702", size = 8507994, upload-time = "2025-12-10T07:08:23.943Z" },
-    { url = "https://files.pythonhosted.org/packages/5e/37/e192ea709551799379958b4c4771ec507347027bb7c942662c7fbeba31cb/scikit_learn-1.8.0-cp313-cp313t-win_arm64.whl", hash = "sha256:bf97c10a3f5a7543f9b88cbf488d33d175e9146115a451ae34568597ba33dcde", size = 7869518, upload-time = "2025-12-10T07:08:25.71Z" },
-    { url = "https://files.pythonhosted.org/packages/24/05/1af2c186174cc92dcab2233f327336058c077d38f6fe2aceb08e6ab4d509/scikit_learn-1.8.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:c22a2da7a198c28dd1a6e1136f19c830beab7fdca5b3e5c8bba8394f8a5c45b3", size = 8528667, upload-time = "2025-12-10T07:08:27.541Z" },
-    { url = "https://files.pythonhosted.org/packages/a8/25/01c0af38fe969473fb292bba9dc2b8f9b451f3112ff242c647fee3d0dfe7/scikit_learn-1.8.0-cp314-cp314-macosx_12_0_arm64.whl", hash = "sha256:6b595b07a03069a2b1740dc08c2299993850ea81cce4fe19b2421e0c970de6b7", size = 8066524, upload-time = "2025-12-10T07:08:29.822Z" },
-    { url = "https://files.pythonhosted.org/packages/be/ce/a0623350aa0b68647333940ee46fe45086c6060ec604874e38e9ab7d8e6c/scikit_learn-1.8.0-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:29ffc74089f3d5e87dfca4c2c8450f88bdc61b0fc6ed5d267f3988f19a1309f6", size = 8657133, upload-time = "2025-12-10T07:08:31.865Z" },
-    { url = "https://files.pythonhosted.org/packages/b8/cb/861b41341d6f1245e6ca80b1c1a8c4dfce43255b03df034429089ca2a2c5/scikit_learn-1.8.0-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:fb65db5d7531bccf3a4f6bec3462223bea71384e2cda41da0f10b7c292b9e7c4", size = 8923223, upload-time = "2025-12-10T07:08:34.166Z" },
-    { url = "https://files.pythonhosted.org/packages/76/18/a8def8f91b18cd1ba6e05dbe02540168cb24d47e8dcf69e8d00b7da42a08/scikit_learn-1.8.0-cp314-cp314-win_amd64.whl", hash = "sha256:56079a99c20d230e873ea40753102102734c5953366972a71d5cb39a32bc40c6", size = 8096518, upload-time = "2025-12-10T07:08:36.339Z" },
-    { url = "https://files.pythonhosted.org/packages/d1/77/482076a678458307f0deb44e29891d6022617b2a64c840c725495bee343f/scikit_learn-1.8.0-cp314-cp314-win_arm64.whl", hash = "sha256:3bad7565bc9cf37ce19a7c0d107742b320c1285df7aab1a6e2d28780df167242", size = 7754546, upload-time = "2025-12-10T07:08:38.128Z" },
-    { url = "https://files.pythonhosted.org/packages/2d/d1/ef294ca754826daa043b2a104e59960abfab4cf653891037d19dd5b6f3cf/scikit_learn-1.8.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:4511be56637e46c25721e83d1a9cea9614e7badc7040c4d573d75fbe257d6fd7", size = 8848305, upload-time = "2025-12-10T07:08:41.013Z" },
-    { url = "https://files.pythonhosted.org/packages/5b/e2/b1f8b05138ee813b8e1a4149f2f0d289547e60851fd1bb268886915adbda/scikit_learn-1.8.0-cp314-cp314t-macosx_12_0_arm64.whl", hash = "sha256:a69525355a641bf8ef136a7fa447672fb54fe8d60cab5538d9eb7c6438543fb9", size = 8432257, upload-time = "2025-12-10T07:08:42.873Z" },
-    { url = "https://files.pythonhosted.org/packages/26/11/c32b2138a85dcb0c99f6afd13a70a951bfdff8a6ab42d8160522542fb647/scikit_learn-1.8.0-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c2656924ec73e5939c76ac4c8b026fc203b83d8900362eb2599d8aee80e4880f", size = 8678673, upload-time = "2025-12-10T07:08:45.362Z" },
-    { url = "https://files.pythonhosted.org/packages/c7/57/51f2384575bdec454f4fe4e7a919d696c9ebce914590abf3e52d47607ab8/scikit_learn-1.8.0-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:15fc3b5d19cc2be65404786857f2e13c70c83dd4782676dd6814e3b89dc8f5b9", size = 8922467, upload-time = "2025-12-10T07:08:47.408Z" },
-    { url = "https://files.pythonhosted.org/packages/35/4d/748c9e2872637a57981a04adc038dacaa16ba8ca887b23e34953f0b3f742/scikit_learn-1.8.0-cp314-cp314t-win_amd64.whl", hash = "sha256:00d6f1d66fbcf4eba6e356e1420d33cc06c70a45bb1363cd6f6a8e4ebbbdece2", size = 8774395, upload-time = "2025-12-10T07:08:49.337Z" },
-    { url = "https://files.pythonhosted.org/packages/60/22/d7b2ebe4704a5e50790ba089d5c2ae308ab6bb852719e6c3bd4f04c3a363/scikit_learn-1.8.0-cp314-cp314t-win_arm64.whl", hash = "sha256:f28dd15c6bb0b66ba09728cf09fd8736c304be29409bd8445a080c1280619e8c", size = 8002647, upload-time = "2025-12-10T07:08:51.601Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/01/cf3310626b6d48d3e9be69a1223f9180360b5e6edb045f50fade723ce494/scikit_learn-1.9.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:80746d63bd4b6eaca54d36fe5feaf4d28bb38dc6f9470f81c7cad7c40155f119", size = 8705188, upload-time = "2026-06-02T11:53:41.964Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/04/5acd7ae280c5f93b6ac5ef6cdec14eef4c8d1cd91d85b3292989c94d96b1/scikit_learn-1.9.0-cp313-cp313-macosx_12_0_arm64.whl", hash = "sha256:5b934c45c252844a91d69fda3a34cff5e7307e1db10d77cb10a3980312c74713", size = 8228299, upload-time = "2026-06-02T11:53:44.817Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/39/ffe829a5b8ecb40a518724a997794657fdc354ada5e8fe8e64d998c0bac9/scikit_learn-1.9.0-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:38c3dcb9a1ffb85505ec53d54c7b4aea0cff70050425a7760c2af661ac85df05", size = 8789690, upload-time = "2026-06-02T11:53:47.461Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/88/8dab5de10c638c083772a6be83a3d8106ced492f74a928c8693638e5bb50/scikit_learn-1.9.0-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:da76d09304a4706db7cc1e3ebaa3b6b98a67365cc11d2996c4f1e58ba47df714", size = 9087723, upload-time = "2026-06-02T11:53:50.702Z" },
+    { url = "https://files.pythonhosted.org/packages/20/3f/7917ca72464038f6240ec70c29f94862d08a34a74291ae4d4ec5eb8186a0/scikit_learn-1.9.0-cp313-cp313-win_amd64.whl", hash = "sha256:5808d98f15c6bf6d9d96d2348c1997392a5888ce7097e664105f930c4bca1277", size = 8184330, upload-time = "2026-06-02T11:53:53.396Z" },
+    { url = "https://files.pythonhosted.org/packages/78/c7/15739eb2f61fda3c54639e9942414e5a19ad8a8d1f5a3266afad7cb7df80/scikit_learn-1.9.0-cp313-cp313-win_arm64.whl", hash = "sha256:d77f54c017633791bc0225a43e2f8d03745fdcfe4880268fcc4df15f505dec2e", size = 7840653, upload-time = "2026-06-02T11:53:56.035Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/7d/c9a35cf59b20a86fec24d306f1547b78dec194b08d367ce2a3e4854169d9/scikit_learn-1.9.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:9656acd4e93f74e0b66c8a36c88830a99252dfa900044d36bc2212ae89a47162", size = 8713289, upload-time = "2026-06-02T11:53:58.788Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/a7/552a7821597c632b907f7bfe8f36f9f572777af8ef8a48353041cf8e091a/scikit_learn-1.9.0-cp314-cp314-macosx_12_0_arm64.whl", hash = "sha256:24360002ae845e7866522b0a5bbf690802e7bc388cac8663502e78aa98598aa2", size = 8245141, upload-time = "2026-06-02T11:54:01.694Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/79/f4a0c4fe9711154cddabf913471153af79056382ddc612cfe5ee0ff4b72e/scikit_learn-1.9.0-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5162ad10a418c8a282dde04c9aa06965de3e9a65f33c1440c0ae69bb1a09d913", size = 8847671, upload-time = "2026-06-02T11:54:04.448Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/af/4d72d9e475ac83719160c662619e4bf7b95c19507cd582e7d0167a3c3dae/scikit_learn-1.9.0-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1fea2cc5677ab49d6f5bade978c866da44957b712d92e9635e8b4f723013c3cb", size = 9118104, upload-time = "2026-06-02T11:54:07.205Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/d5/6a58eea2cb9abbb9b3f2bb8b2cfb3243d1152d69f442d256c7af71304769/scikit_learn-1.9.0-cp314-cp314-win_amd64.whl", hash = "sha256:64fa347efc1c839c487433e40c5144d38c336e8a2b59c81aa8660373945c2673", size = 8290674, upload-time = "2026-06-02T11:54:10.087Z" },
+    { url = "https://files.pythonhosted.org/packages/65/5b/d4c879cf358f1187141cf90ced473f087183489090244f50c124a2ee478b/scikit_learn-1.9.0-cp314-cp314-win_arm64.whl", hash = "sha256:1b944b6db288f6b926e3650026ddafb988929de95d11fc2cc5fa117773c9ba42", size = 7978807, upload-time = "2026-06-02T11:54:12.769Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/43/bfae3121ec67ae09150d453c442c7c1cc166e9aefe056e6ab3b7728a5cfc/scikit_learn-1.9.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:4ccacf04ca5f4b492158a5f28afe0ace43f81b2571e4b9a66d34848b46128949", size = 9031941, upload-time = "2026-06-02T11:54:15.436Z" },
+    { url = "https://files.pythonhosted.org/packages/75/b0/20a4546eb17f3b25d3c66df15810411c14ed5065bcfab50b53c96fb627b2/scikit_learn-1.9.0-cp314-cp314t-macosx_12_0_arm64.whl", hash = "sha256:ee1a8db2c18c08e34c7412d4b10be1cac214cd4ea7dc9715a6a327eb49a37c96", size = 8613528, upload-time = "2026-06-02T11:54:18.842Z" },
+    { url = "https://files.pythonhosted.org/packages/18/3c/e440e039bb82cd19004edaaad00acbde0fb9b461083c3ecf37941c557312/scikit_learn-1.9.0-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:147e9329ef0e39f75d4cffa02b2aa48d827832684926cd5210d9a2cb5c57246b", size = 8855050, upload-time = "2026-06-02T11:54:21.699Z" },
+    { url = "https://files.pythonhosted.org/packages/43/26/b341b8dab5998da6270a3a42c2152c578501354d36f944b5856757035ef8/scikit_learn-1.9.0-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5bad8f8b9950321b54c965fdcbac6c6c55e79e16646b49977bcf3668d3870a1a", size = 9097190, upload-time = "2026-06-02T11:54:24.454Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/de/b650b4d69b84468cfa2e28a3ff7b8103743029e6446ce1a97fe060ef688c/scikit_learn-1.9.0-cp314-cp314t-win_amd64.whl", hash = "sha256:78fc56eafd4edb9575d2d8950d1dd152061abb573341a1cb7e099fc40f6c6666", size = 8963204, upload-time = "2026-06-02T11:54:27.428Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/f3/ff83d76d7418112e5a61326443cdda87be3545dd8d6599c95b2481a4419e/scikit_learn-1.9.0-cp314-cp314t-win_arm64.whl", hash = "sha256:051075bda8b7aab87b1906ab3d4740a1e1224a19d7b3781a576736edc94e76aa", size = 8222661, upload-time = "2026-06-02T11:54:30.192Z" },
 ]
 
 [[package]]
@@ -4106,14 +4127,14 @@ wheels = [
 
 [[package]]
 name = "starlette"
-version = "0.52.1"
+version = "1.2.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c4/68/79977123bb7be889ad680d79a40f339082c1978b5cfcf62c2d8d196873ac/starlette-0.52.1.tar.gz", hash = "sha256:834edd1b0a23167694292e94f597773bc3f89f362be6effee198165a35d62933", size = 2653702, upload-time = "2026-01-18T13:34:11.062Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/25/44/ec35f1b6e83094b997da438a02c8c9b0ade2b1e84cfc48bd4656780760a6/starlette-1.2.1.tar.gz", hash = "sha256:9b9b5ebb992e67d6093741e63c2f59e4f6fff986f81163c087867bd7b924b3f6", size = 2701854, upload-time = "2026-05-31T01:07:51.847Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/81/0d/13d1d239a25cbfb19e740db83143e95c772a1fe10202dda4b76792b114dd/starlette-0.52.1-py3-none-any.whl", hash = "sha256:0029d43eb3d273bc4f83a08720b4912ea4b071087a3b48db01b7c839f7954d74", size = 74272, upload-time = "2026-01-18T13:34:09.188Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/54/196d0c1db10af76baa4f64894448505d60d3cdf70ef92cbb35f46a4e4c71/starlette-1.2.1-py3-none-any.whl", hash = "sha256:4de0082d08c8f6764a85a54cf1120d6939507a19905c7768acad2a9f875d2b89", size = 73350, upload-time = "2026-05-31T01:07:50.09Z" },
 ]
 
 [[package]]
@@ -4268,19 +4289,19 @@ wheels = [
 
 [[package]]
 name = "tornado"
-version = "6.5.5"
+version = "6.5.6"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/f8/f1/3173dfa4a18db4a9b03e5d55325559dab51ee653763bb8745a75af491286/tornado-6.5.5.tar.gz", hash = "sha256:192b8f3ea91bd7f1f50c06955416ed76c6b72f96779b962f07f911b91e8d30e9", size = 516006, upload-time = "2026-03-10T21:31:02.067Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/50/57/6d7303a77ae439d9189108f76c0c4fd89ee5e2cc8387bffb55232565c4ed/tornado-6.5.6.tar.gz", hash = "sha256:9a365179fe8ff6b8766f602c0f67c185d778193e9bdd828b19f0b6ed7764177d", size = 518139, upload-time = "2026-05-27T15:35:54.646Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/59/8c/77f5097695f4dd8255ecbd08b2a1ed8ba8b953d337804dd7080f199e12bf/tornado-6.5.5-cp39-abi3-macosx_10_9_universal2.whl", hash = "sha256:487dc9cc380e29f58c7ab88f9e27cdeef04b2140862e5076a66fb6bb68bb1bfa", size = 445983, upload-time = "2026-03-10T21:30:44.28Z" },
-    { url = "https://files.pythonhosted.org/packages/ab/5e/7625b76cd10f98f1516c36ce0346de62061156352353ef2da44e5c21523c/tornado-6.5.5-cp39-abi3-macosx_10_9_x86_64.whl", hash = "sha256:65a7f1d46d4bb41df1ac99f5fcb685fb25c7e61613742d5108b010975a9a6521", size = 444246, upload-time = "2026-03-10T21:30:46.571Z" },
-    { url = "https://files.pythonhosted.org/packages/b2/04/7b5705d5b3c0fab088f434f9c83edac1573830ca49ccf29fb83bf7178eec/tornado-6.5.5-cp39-abi3-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:e74c92e8e65086b338fd56333fb9a68b9f6f2fe7ad532645a290a464bcf46be5", size = 447229, upload-time = "2026-03-10T21:30:48.273Z" },
-    { url = "https://files.pythonhosted.org/packages/34/01/74e034a30ef59afb4097ef8659515e96a39d910b712a89af76f5e4e1f93c/tornado-6.5.5-cp39-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:435319e9e340276428bbdb4e7fa732c2d399386d1de5686cb331ec8eee754f07", size = 448192, upload-time = "2026-03-10T21:30:51.22Z" },
-    { url = "https://files.pythonhosted.org/packages/be/00/fe9e02c5a96429fce1a1d15a517f5d8444f9c412e0bb9eadfbe3b0fc55bf/tornado-6.5.5-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:3f54aa540bdbfee7b9eb268ead60e7d199de5021facd276819c193c0fb28ea4e", size = 448039, upload-time = "2026-03-10T21:30:53.52Z" },
-    { url = "https://files.pythonhosted.org/packages/82/9e/656ee4cec0398b1d18d0f1eb6372c41c6b889722641d84948351ae19556d/tornado-6.5.5-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:36abed1754faeb80fbd6e64db2758091e1320f6bba74a4cf8c09cd18ccce8aca", size = 447445, upload-time = "2026-03-10T21:30:55.541Z" },
-    { url = "https://files.pythonhosted.org/packages/5a/76/4921c00511f88af86a33de770d64141170f1cfd9c00311aea689949e274e/tornado-6.5.5-cp39-abi3-win32.whl", hash = "sha256:dd3eafaaeec1c7f2f8fdcd5f964e8907ad788fe8a5a32c4426fbbdda621223b7", size = 448582, upload-time = "2026-03-10T21:30:57.142Z" },
-    { url = "https://files.pythonhosted.org/packages/2c/23/f6c6112a04d28eed765e374435fb1a9198f73e1ec4b4024184f21faeb1ad/tornado-6.5.5-cp39-abi3-win_amd64.whl", hash = "sha256:6443a794ba961a9f619b1ae926a2e900ac20c34483eea67be4ed8f1e58d3ef7b", size = 448990, upload-time = "2026-03-10T21:30:58.857Z" },
-    { url = "https://files.pythonhosted.org/packages/b7/c8/876602cbc96469911f0939f703453c1157b0c826ecb05bdd32e023397d4e/tornado-6.5.5-cp39-abi3-win_arm64.whl", hash = "sha256:2c9a876e094109333f888539ddb2de4361743e5d21eece20688e3e351e4990a6", size = 448016, upload-time = "2026-03-10T21:31:00.43Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/0d/b4f481e18c5a51864e6d12b9a05ecf72919696680b747c958c3fc1f4fbae/tornado-6.5.6-cp39-abi3-macosx_10_9_universal2.whl", hash = "sha256:65fcfaafb079435c2c19dc9e07c0f1cf0fa9051759ed0a7d0a3ba7ea7f64919c", size = 447737, upload-time = "2026-05-27T15:35:38.122Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/9c/5430c39fcab1144d35860f457b15e9c08b4bc7ac86764354204e983d6183/tornado-6.5.6-cp39-abi3-macosx_10_9_x86_64.whl", hash = "sha256:38bc01b4acacded2de63ae78023548e41ebe6fbed3ec05a796d7ae3ad893887e", size = 445899, upload-time = "2026-05-27T15:35:40.519Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/79/fa7e14a2f939c807a8d30619b4eb604eab219601b78792516ebe22d40cf9/tornado-6.5.6-cp39-abi3-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:b942e6a137fda31ff54bf8e6e2c8d1c37f1f50583f3ed53fb840b53b9601d104", size = 448964, upload-time = "2026-05-27T15:35:42.106Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/71/bd67d5f5199f937dafe03a49a37989f60f600ff6fef34c79412a829d97bd/tornado-6.5.6-cp39-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8666946e70171b8c3f1fc9b7876fac492e84822c4c7f3746f4e8f8bc9ac92a79", size = 449935, upload-time = "2026-05-27T15:35:43.906Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/a4/c24388c9cf5b3c3a513b56a158af9f23092c9a2810d789e294310797df21/tornado-6.5.6-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:1c34cfab7ad6d104f052f55de06d39bbafc5885cfeb4da688803308dbcfa90b7", size = 449767, upload-time = "2026-05-27T15:35:45.793Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/eb/6a07ad550c3f7b37244bd0becdf293ec3d3e961783d8b720a97df50de1b2/tornado-6.5.6-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:385f35e4e22fb52551dfcda4cdc8c30c61c2c001aef5ddad99cdfe116952efd3", size = 449174, upload-time = "2026-05-27T15:35:47.485Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/84/3469e098dccdb6763130e06aacd786bb4363fca7b590a55c101ddf34ed30/tornado-6.5.6-cp39-abi3-win32.whl", hash = "sha256:db475f1b67b2809b10bb16264829087724ca8d24fe4ed47f7b8675cae453ef86", size = 450230, upload-time = "2026-05-27T15:35:49.322Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/3c/273a04e0b9dd9016f1685cca0c1c8795a71ac88a34a8c889a0b443483226/tornado-6.5.6-cp39-abi3-win_amd64.whl", hash = "sha256:6739bf1e8eb09230f1280ddbd3236f0309db70f2c551a8dbc40f62babdf82f79", size = 450667, upload-time = "2026-05-27T15:35:51.194Z" },
+    { url = "https://files.pythonhosted.org/packages/02/98/0cffe22a224f60c5fb1e3aa0b76f9da2e1ca78b0e9545e3d077c68ce60a7/tornado-6.5.6-cp39-abi3-win_arm64.whl", hash = "sha256:2543597b24a695d72338a9a77818362d72387c03ae173f1f169eadc5c91466ac", size = 449690, upload-time = "2026-05-27T15:35:52.902Z" },
 ]
 
 [[package]]
@@ -4297,16 +4318,16 @@ wheels = [
 
 [[package]]
 name = "traitlets"
-version = "5.15.0"
+version = "5.15.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/1b/22/40f55b26baeab80c2d7b3f1db0682f8954e4617fee7d90ce634022ef05c6/traitlets-5.15.0.tar.gz", hash = "sha256:4fead733f81cf1c4c938e06f8ca4633896833c9d89eff878159457f4d4392971", size = 163197, upload-time = "2026-05-06T08:05:58.016Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/57/a9/a2584b8313b89f94869ddb3c4074617a691de1812a614d2d50e32ca5a7a6/traitlets-5.15.1.tar.gz", hash = "sha256:7b1c07854fe25acb39e009bae49f11b79ff6cbb2f27999104e9110e7a6b53722", size = 163344, upload-time = "2026-06-03T12:26:06.181Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/da/98/a9937a969d018a23badfea0b381f66783649d48e0ea6c41923265c3cbeb3/traitlets-5.15.0-py3-none-any.whl", hash = "sha256:fb36a18867a6803deab09f3c5e0fa81bb7b26a5c9e82501c9933f759166eff40", size = 85877, upload-time = "2026-05-06T08:05:55.853Z" },
+    { url = "https://files.pythonhosted.org/packages/96/8d/1080ee4c231f361b6ce4470d556c8c435b67c7e0753aaa641497ee92f88b/traitlets-5.15.1-py3-none-any.whl", hash = "sha256:770a53705f84b81ac107e83a1b3328ff2dae16094d8fc3cfc004e4b22dfd8e92", size = 85858, upload-time = "2026-06-03T12:26:04.395Z" },
 ]
 
 [[package]]
 name = "transformers"
-version = "5.9.0"
+version = "5.10.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "huggingface-hub" },
@@ -4319,9 +4340,9 @@ dependencies = [
     { name = "tqdm" },
     { name = "typer" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/51/58/7f843608f2e8421f86bb97060b54649be6239ec612b82bf9d41e65c26c00/transformers-5.9.0.tar.gz", hash = "sha256:25997cb8fa6053533171634b6162d7df54346530ec2aa9b42bb834e63668c842", size = 8642240, upload-time = "2026-05-20T14:50:49.278Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/65/d3/5b7c2f1a52ff0e57355efdc21554aab7e4602f6592ab4582a34c988ab956/transformers-5.10.1.tar.gz", hash = "sha256:31112d1dcdfcf9934242acbba891f44e2279ff74b9b8ba4595640e0e04195a3a", size = 8798372, upload-time = "2026-06-03T15:37:03.289Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/02/ca/2eaa5359f2ccb8c2e1656bc26305ad0cf438aa392ce4b29ae67a315c186e/transformers-5.9.0-py3-none-any.whl", hash = "sha256:1d19509bcff7028ebc6b277d71caa712e8353778463d38764237d14b42b52788", size = 10787648, upload-time = "2026-05-20T14:50:45.337Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/8c/3119596c7fcd9b8b8d924d5b5ba1bfdfafd6d8738bdd81ca09c60b4a38b3/transformers-5.10.1-py3-none-any.whl", hash = "sha256:ccb919ea1b77338b44d0d45d23f7472081906b1bb6ed8e5f5cf4d692d1da03d4", size = 11003770, upload-time = "2026-06-03T15:37:00.433Z" },
 ]
 
 [[package]]
@@ -4416,28 +4437,28 @@ wheels = [
 
 [[package]]
 name = "uv"
-version = "0.11.16"
+version = "0.11.18"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/a1/99/025154611a4bd97a23851574c15d73bb71ada09d35f092d6972f9ac87f70/uv-0.11.16.tar.gz", hash = "sha256:4b435fcb0af8f34833dcc1903a8a223856437efd0d515c2160a2871def221238", size = 4177038, upload-time = "2026-05-21T22:10:01.009Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/68/ea/c25007a2964e5f5f5300db2cab16fe8c2fc1284f0b9bea6212e06097d05b/uv-0.11.18.tar.gz", hash = "sha256:61f2bc99898383f9bf04e24b984e42e19cde378dd79192935ca21d75563368a8", size = 4209283, upload-time = "2026-06-01T19:43:07.998Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/55/e3/8b8cfc802bc476c67e31a39725538193265cf3a19585b4a60c232659f919/uv-0.11.16-py3-none-linux_armv6l.whl", hash = "sha256:c9e9d9cb73ee8cd2ad696dbf1bc3232abaac363270557684b6b85a2bdb8eb276", size = 23508087, upload-time = "2026-05-21T22:10:06.227Z" },
-    { url = "https://files.pythonhosted.org/packages/45/78/d5ca91c636ac88e902b6b3ff31ad32d2d02663232d844aff871467a323d2/uv-0.11.16-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:01172238a75e42a5a55d12555cd9ec98bee24249f3645b98a4b32eb5f1ff5e43", size = 23028989, upload-time = "2026-05-21T22:09:50.127Z" },
-    { url = "https://files.pythonhosted.org/packages/c7/26/c84580dfec5a87c36fb1218eac17c5194fa3e58e2a9232cf085d69eb6bed/uv-0.11.16-py3-none-macosx_11_0_arm64.whl", hash = "sha256:c75f9b5bac49b97131973910c220feac60fe47b10a333941b237ff0ae4b36721", size = 21572023, upload-time = "2026-05-21T22:09:58.703Z" },
-    { url = "https://files.pythonhosted.org/packages/84/68/ba2bdc64fea96ef8c9796a991f244541b65bb9d31c661b322cc724857a4e/uv-0.11.16-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.musllinux_1_1_aarch64.whl", hash = "sha256:a801484f4507b6c2133e557350f3143b61b8f8b61dddb01ff7b84a74cdfab1fb", size = 23289936, upload-time = "2026-05-21T22:10:15.423Z" },
-    { url = "https://files.pythonhosted.org/packages/c9/81/74922f693d5804a77d009338ca8dc709eff871fb60d9f2c263dede8d77d1/uv-0.11.16-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.musllinux_1_1_armv7l.whl", hash = "sha256:eb538069e768b042cf870be700a210518ce628e36d99d9a83b85acaf484d7f6a", size = 23020906, upload-time = "2026-05-21T22:10:24.242Z" },
-    { url = "https://files.pythonhosted.org/packages/60/81/cda8886f5df4dd28854a9b97bcc3ee6a7d1b5b5b23aaaccfbf1ed3e5e2bf/uv-0.11.16-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:d7cdb23457a4d1bc76bf1016638ea1d1ada0e8e032f656168e933d4d17c47e72", size = 23004220, upload-time = "2026-05-21T22:10:32.847Z" },
-    { url = "https://files.pythonhosted.org/packages/98/7c/65837e07de23f0a40ab860bc6601f7c022d4bcf4b97ca79b6c35a2e72e65/uv-0.11.16-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:451327388d59ac3041cbda474296f3ceeafac5b1f645476198e7b95f504fcfd5", size = 24319651, upload-time = "2026-05-21T22:10:21.492Z" },
-    { url = "https://files.pythonhosted.org/packages/85/70/9d364542bf118433b60ed71422e47d2c8c470aca7d3aef0df9449a5f726a/uv-0.11.16-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:e7992b8276149b3ffaf35ce9434702d3e16bae6ec393e99df209b870a7e19eb0", size = 25359517, upload-time = "2026-05-21T22:09:46.519Z" },
-    { url = "https://files.pythonhosted.org/packages/99/b4/650896e8cff5a3289cee860c41fd9876da83ca628c5871f9a61d5fc75c72/uv-0.11.16-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:83a8db9b3314d900e7a240105afce43f806c9e04c59ea10a40bdbdca84c6d0c5", size = 24563421, upload-time = "2026-05-21T22:10:35.82Z" },
-    { url = "https://files.pythonhosted.org/packages/b1/7d/184711a8c02466e1486d57efdc9394ce09cbf43ee2c5794da70bd25db3fb/uv-0.11.16-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9b10086165189c39c53142a0e2f34e0b8889ef681886f589ed17be45a1a774c7", size = 24676607, upload-time = "2026-05-21T22:10:39.784Z" },
-    { url = "https://files.pythonhosted.org/packages/ee/3f/5b338df6505f77f73c20eae38cb29f57d14dba56dac835386e3dc6e2a5d6/uv-0.11.16-py3-none-manylinux_2_28_aarch64.whl", hash = "sha256:cfe1f06fb8f135a735a961065d5ee90f99cccf41749fb1f964edb5b3c3dae19b", size = 23401615, upload-time = "2026-05-21T22:10:30.124Z" },
-    { url = "https://files.pythonhosted.org/packages/b6/f9/54bbcbc77443dc76468f09a49cc9f4f92ca49b4159a011c6010d223de4ea/uv-0.11.16-py3-none-manylinux_2_31_riscv64.musllinux_1_1_riscv64.whl", hash = "sha256:2454f80d8b548fb2e246151578809b14ad4395b3f357d738bae1af11918e91af", size = 24104468, upload-time = "2026-05-21T22:09:53.323Z" },
-    { url = "https://files.pythonhosted.org/packages/3e/0a/b5f105514fddea5110fe3947cd18a9f199ff93dbad78e5e5a08e1b5d0ea2/uv-0.11.16-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:4249d57a563165d368050680deeb722f9c0053a0dbf3244b11cca3e6d85a3c7d", size = 24164861, upload-time = "2026-05-21T22:10:09.458Z" },
-    { url = "https://files.pythonhosted.org/packages/f6/01/15d4ca2be7257862b077a9077ac31ce81c419f35ef7994e76356a317716b/uv-0.11.16-py3-none-musllinux_1_1_i686.whl", hash = "sha256:374c30126483ce95675c5de49e54c2454ddedb01c17b8321417fe4eb9da83406", size = 23644919, upload-time = "2026-05-21T22:10:03.129Z" },
-    { url = "https://files.pythonhosted.org/packages/49/bf/9de3e262e6ff93aec2e0a4c238857293fd2c616dd79f25bb440f126bf32c/uv-0.11.16-py3-none-musllinux_1_1_x86_64.whl", hash = "sha256:746edfc9d1d8cd03dd58739989f634d3580648048d09f81a9c68da74c4eb9d62", size = 24973746, upload-time = "2026-05-21T22:10:18.413Z" },
-    { url = "https://files.pythonhosted.org/packages/f6/7d/f4126dce104f1b5d0b451ce3ca41c4db69b963c2e78c3465fcda6440de31/uv-0.11.16-py3-none-win32.whl", hash = "sha256:50299b20aab2d28c05ff27d781ce2af3f5af2102bc304dc07a4ad54b05e2af8a", size = 22400991, upload-time = "2026-05-21T22:10:27.119Z" },
-    { url = "https://files.pythonhosted.org/packages/8f/38/99627cb995a03389b227ce4b12b08e770565d0aa7850cd0420973194a638/uv-0.11.16-py3-none-win_amd64.whl", hash = "sha256:e901aafa5007beffafe57bfa44e5e248d99fb5d97036a3718fd65cf9723c5cd3", size = 25067163, upload-time = "2026-05-21T22:10:12.317Z" },
-    { url = "https://files.pythonhosted.org/packages/b6/68/3ed1c0bdfb4bec501e5cde73419b4f39c8a125ef905a85fc0f239f19eb9b/uv-0.11.16-py3-none-win_arm64.whl", hash = "sha256:d777cb29661cdfa7f90dae77406c85fb5b729bf8bc13941dc237958a1ea1ba00", size = 23502015, upload-time = "2026-05-21T22:09:56.014Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/f1/692f05ecffe73a8bbf62c19ed3ed897556c1a4b00a7b2dd18e5b73f92daa/uv-0.11.18-py3-none-linux_armv6l.whl", hash = "sha256:b35d25a5fda7d058b1684476a47555afbe0e9560318c7a8f72cccc6b77b42e1a", size = 23592196, upload-time = "2026-06-01T19:42:27.089Z" },
+    { url = "https://files.pythonhosted.org/packages/38/ad/57a31ea9ffc53a2fb5cd9a60b5edb9e4df7c526ba80be4517c6d73cf4fa7/uv-0.11.18-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:90685bda9e15600ae9a2a10c326008a69f28d8652555a2e760e1493e4b1ae7b5", size = 23193111, upload-time = "2026-06-01T19:42:52.293Z" },
+    { url = "https://files.pythonhosted.org/packages/af/3b/130515418bdd4be1aec5941ca2fa53dc0281750434e835ff633e6f8cd944/uv-0.11.18-py3-none-macosx_11_0_arm64.whl", hash = "sha256:0571ec649f25e2cca9eb994637aa1ae27ab3db58f87c5a9b5f9776d5d7cd2298", size = 21621552, upload-time = "2026-06-01T19:42:49.709Z" },
+    { url = "https://files.pythonhosted.org/packages/95/de/7dccc8c8449235172e872a9b13b03a67e4f7975ffb875da70a3eada8a4f6/uv-0.11.18-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.musllinux_1_1_aarch64.whl", hash = "sha256:5df2b2a59f1ee4392066df24ef9904b3bbdc226e8ab9bdff8e290127fcddc3a3", size = 23456077, upload-time = "2026-06-01T19:43:00.595Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/26/7490fc8a7b56847ce4aabcb40b0a938f4daf79fd7bd3a8f3a6d6babe00cc/uv-0.11.18-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.musllinux_1_1_armv7l.whl", hash = "sha256:351db8ef413055b7e8e894ff54f30ce3fd001f4f3bbae66c2f519f30008fa5b5", size = 23147860, upload-time = "2026-06-01T19:42:57.748Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/56/deddff68533144d7c40a2793914fa2994d0273ef105144cbcd3c08f80eb3/uv-0.11.18-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:0adb4553e7962132f4d3a3bcbdc49332008486fc7f3e147636c18fdc49dac17e", size = 23168337, upload-time = "2026-06-01T19:42:38.344Z" },
+    { url = "https://files.pythonhosted.org/packages/69/b0/71473c35536b92bc94a0ec317a7bddf800aeb90ad341044f61e17a45c6f4/uv-0.11.18-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:f9c2ab380ffafa1d754c92799ce818ce9bb20a5b053538e391fbdf0d10954a6a", size = 24543532, upload-time = "2026-06-01T19:43:03.348Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/74/00a422128320ed174c15b0ff7084533280850853592cf802c2f3e3bd25c2/uv-0.11.18-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:73c59f8bca927b922b897a2d6123e45146dc97bfc73aab40ae10359ee37897c4", size = 25497616, upload-time = "2026-06-01T19:42:32.991Z" },
+    { url = "https://files.pythonhosted.org/packages/57/b9/a74e7a5029f7eebd7f8c45f6e87fbb2855705dd595980328e2403317a588/uv-0.11.18-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:6f2d8240e4b8eaa9507d423ede6cca8396057a24d398b89fbcc3117c79e8a42d", size = 24731187, upload-time = "2026-06-01T19:42:35.647Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/c4/8112b3c95db60a39c98db0641dd49bd4228f2fedb9d0ef5e4f3f48b52a0d/uv-0.11.18-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9a4ee93dd0cc86046eb234ff8f3a5090c6cbb1466a825c5201aaf4ee4b45158d", size = 24868841, upload-time = "2026-06-01T19:42:46.905Z" },
+    { url = "https://files.pythonhosted.org/packages/39/5b/1adc8261a132604bac83438f77080b1cea4b87a633890c6b68dac0d68400/uv-0.11.18-py3-none-manylinux_2_28_aarch64.whl", hash = "sha256:57f4e2dea12cac7749628bc87eb66d3aaa5c3ed27420598899d6d82aee4d1b0d", size = 23536198, upload-time = "2026-06-01T19:42:41.196Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/16/44b5f182c5fc442ec8866c84cceec7675b7430417dcf119c1d5b656bce89/uv-0.11.18-py3-none-manylinux_2_31_riscv64.musllinux_1_1_riscv64.whl", hash = "sha256:8b7708376d0c79f84403d293c0774e0de76a7546e1cc80e911d0fed83cee65bf", size = 24290310, upload-time = "2026-06-01T19:43:15.415Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/43/021c0033918330f681eb3dafcf44db4b746978b0adb9c6851b2177597b56/uv-0.11.18-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:df158cc578aa4acff250505eab422a19794c9ff732dcab9faa068caa9dbe661d", size = 24380029, upload-time = "2026-06-01T19:43:12.746Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/38/2474a09f24ef57cfe99549a8d2d1a887549bab522a193ad50706a4fff021/uv-0.11.18-py3-none-musllinux_1_1_i686.whl", hash = "sha256:24f251b09f6dd7c367520b6b62e22038b92c18ce56ecee8b426a6cd78151466f", size = 23854064, upload-time = "2026-06-01T19:42:54.948Z" },
+    { url = "https://files.pythonhosted.org/packages/75/6a/faa140a30e993453400f94ad5675c9d0673a71191ff523d3117c312779a6/uv-0.11.18-py3-none-musllinux_1_1_x86_64.whl", hash = "sha256:6e461d64cdc957da38fec9946758020ee3a66b4508f76cb940a866f704b20355", size = 25055765, upload-time = "2026-06-01T19:43:09.914Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/8a/077ded1832e92161fc880a420fbd513495369716531055215399d3056eba/uv-0.11.18-py3-none-win32.whl", hash = "sha256:97d60103eec0c4295c2728f0483def79d62a3f265baa11fdf94912c8f10be019", size = 22415962, upload-time = "2026-06-01T19:43:05.896Z" },
+    { url = "https://files.pythonhosted.org/packages/58/bc/68cf345e104a958f0b8971ae60a7d27c69b5892dcddc2e1d9e4a62c69931/uv-0.11.18-py3-none-win_amd64.whl", hash = "sha256:cbbedeb5fefd8c346fe2e1d71af229c04ece00a23ce277e9664db088d35c4f67", size = 25135111, upload-time = "2026-06-01T19:42:30.303Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/89/08bf00b50a62639129dd5c65b80a3182e9fddb67899739f9cfdc0ae1f138/uv-0.11.18-py3-none-win_arm64.whl", hash = "sha256:c9f61f96aa88ec1a890a50ca45fc05b51f4f066699e001245199895844708e38", size = 23542490, upload-time = "2026-06-01T19:42:44Z" },
 ]
 
 [[package]]
@@ -4455,7 +4476,7 @@ wheels = [
 
 [[package]]
 name = "virtualenv"
-version = "21.3.3"
+version = "21.4.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "distlib" },
@@ -4463,9 +4484,9 @@ dependencies = [
     { name = "platformdirs" },
     { name = "python-discovery" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/15/ba/1f6e8c957e4932be060dcdc482d339c12e0216351478add3645cdaa53c05/virtualenv-21.3.3.tar.gz", hash = "sha256:f5bda277e553b1c2b3c1a8debfc30496e1288cc93ce6b7b71b3280047e317328", size = 7613784, upload-time = "2026-05-13T18:01:30.19Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e1/0d/4e93c8e6d1001a75763f87d8f5ecda8ebc7f4aa2153dddfaf4ae8892821a/virtualenv-21.4.2.tar.gz", hash = "sha256:38e6ee0a555615c0ea9da2ac7e9998fe8dc3b911dd33ad8eaad2020957653b0c", size = 7613326, upload-time = "2026-05-31T17:01:22.827Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f4/34/a9dbe051de88a63eb7408ea66630bac38e72f7f6077d4be58737106860d9/virtualenv-21.3.3-py3-none-any.whl", hash = "sha256:7d5987d8369e098e41406efb780a3d4ca79280097293899e351a6407ee153ab3", size = 7594554, upload-time = "2026-05-13T18:01:27.815Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/c4/557dc082be035381b85fdb2b74e21d3d21b57750b74f2b47a32f3a639ff9/virtualenv-21.4.2-py3-none-any.whl", hash = "sha256:854210ca524a1a4d0d744734f4acbc721c3ffe163b85bbf5d56d14d5ae2f0fae", size = 7594079, upload-time = "2026-05-31T17:01:20.735Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Adds a full SecOps privacy layer that sits between user prompts and any external LLM provider. Every outbound call is scanned for PII, masked or blocked per config, and optionally persisted to an audit log — all driven from `dex.yaml`.

## What's in this PR

### Core (`secops/`)
- **`PrivacyGuard`** — intercepts outbound LLM calls; scans via `PIIDetector`, masks via `MaskingEngine`, blocks when `block_on_detect: true`, logs every call via structlog + optional `AuditLogger`
- **`GuardedProvider`** — decorator wrapper (`ai/routing/guarded.py`) that composes any `BaseProvider` with the guard; raises `PrivacyBlocked` before the inner provider is called on a block
- **`PrivacyGuardConfig`** — typed dataclass built from `dex.yaml`; per-`PIIType` strategy overrides, local-target bypass list, all flags
- Local providers (Ollama, etc.) bypass scanning — data never leaves the machine

### Engine wiring
- `DexEngine._init_privacy_guard()` builds guard + optional `AuditLogger` from `secops.guard` / `secops.audit` config
- `secops.audit.db_path` — empty = in-memory, relative resolved under `.dex/`, absolute used as-is
- Every provider in `model_router` is wrapped with `GuardedProvider` at init time
- `DexBackend` Protocol updated with `privacy_guard` + `secops_audit` fields

### Config schema
- `GuardConfig` — `enabled`, `block_on_detect`, `allow_local`, `log_all_outbound`, `strategies`, `local_targets`
- `AuditConfig` — `enabled`, `db_path`
- `_validate_secops()` in `config/loader.py` — `dex validate` now catches unknown PII types / masking strategies before engine boot

### CLI
```
dex secops status            # guard config from dex.yaml
dex secops scan "some text"  # PII detection + masked output
```

### Fixes (pre-existing)
- `guard.py`: `hasattr` guard replaces incorrect `# type: ignore[arg-type]` on `local_targets` iteration
- `pyproject.toml`: remove stale `opentelemetry.*` from mypy overrides (no imports in src/)
- `legacy.py`: remove wrong TODO — `CsvConnector`/`DuckDBConnector` extend `BaseConnector`, not `DataConnector`

## dex.yaml example

```yaml
secops:
  guard:
    enabled: true
    allow_local: true
    block_on_detect: false
    strategies:
      email: hash
      ssn: redact
      phone: partial
  audit:
    enabled: true
    db_path: "secops_audit.db"
```

## Tests
- `test_secops_guard.py` — 36 unit tests
- `test_privacy_guard_wiring.py` — 10 integration tests
- `test_secops_engine_and_cli.py` — 20 tests

836 passed, 36 skipped. Lint + mypy strict clean.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)